### PR TITLE
Allow URL submission to continue after Baidu quota

### DIFF
--- a/.github/workflows/submit-urls.yml
+++ b/.github/workflows/submit-urls.yml
@@ -139,6 +139,8 @@ jobs:
 
           if echo "$RESPONSE" | grep -q '"success"'; then
             grep -Ff baidu_batch.txt to_submit_baidu.tsv > "$SUCCESS_FILE" || true
+          elif echo "$RESPONSE" | grep -qi 'over quota'; then
+            echo "Baidu quota is exhausted; keeping URLs pending for a future run."
           else
             echo "Baidu submission did not report success." >&2
             exit 1


### PR DESCRIPTION
## Summary
- treat Baidu over-quota responses as a warning so IndexNow and Google sitemap submission can continue
- keep unsubmitted Baidu URLs pending for the next run

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/submit-urls.yml"); puts "yaml ok"'