### PR TITLE
Use direct Google service account auth for sitemap submission

### DIFF
--- a/.github/workflows/submit-urls.yml
+++ b/.github/workflows/submit-urls.yml
@@ -203,21 +203,69 @@ jobs:
           fi
           echo "success_file=$SUCCESS_FILE" >> "$GITHUB_OUTPUT"
 
-      - name: Authenticate to Google Search Console
-        id: auth_google
-        if: env.GOOGLE_SEARCH_CONSOLE_CREDENTIALS_JSON != ''
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ env.GOOGLE_SEARCH_CONSOLE_CREDENTIALS_JSON }}
-          token_format: access_token
-          scopes: https://www.googleapis.com/auth/webmasters
-
       - name: Submit sitemap to Google Search Console
-        if: steps.auth_google.conclusion == 'success'
+        if: env.GOOGLE_SEARCH_CONSOLE_CREDENTIALS_JSON != ''
         env:
-          ACCESS_TOKEN: ${{ steps.auth_google.outputs.access_token }}
+          GOOGLE_CREDS_JSON: ${{ env.GOOGLE_SEARCH_CONSOLE_CREDENTIALS_JSON }}
         run: |
           set -euo pipefail
+          ACCESS_TOKEN=$(python - <<'PY'
+          import base64
+          import json
+          import os
+          import subprocess
+          import tempfile
+          import time
+          import urllib.parse
+          import urllib.request
+
+          creds = json.loads(os.environ["GOOGLE_CREDS_JSON"])
+
+          def b64url(data):
+              return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+          now = int(time.time())
+          header = {"alg": "RS256", "typ": "JWT"}
+          claims = {
+              "iss": creds["client_email"],
+              "scope": "https://www.googleapis.com/auth/webmasters",
+              "aud": "https://oauth2.googleapis.com/token",
+              "iat": now,
+              "exp": now + 3600,
+          }
+          signing_input = ".".join([
+              b64url(json.dumps(header, separators=(",", ":")).encode("utf-8")),
+              b64url(json.dumps(claims, separators=(",", ":")).encode("utf-8")),
+          ]).encode("ascii")
+
+          with tempfile.NamedTemporaryFile("w", delete=False) as key_file:
+              key_file.write(creds["private_key"])
+              key_path = key_file.name
+
+          try:
+              signature = subprocess.check_output(
+                  ["openssl", "dgst", "-sha256", "-sign", key_path],
+                  input=signing_input,
+              )
+          finally:
+              os.unlink(key_path)
+
+          assertion = signing_input.decode("ascii") + "." + b64url(signature)
+          body = urllib.parse.urlencode({
+              "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+              "assertion": assertion,
+          }).encode("utf-8")
+          req = urllib.request.Request(
+              "https://oauth2.googleapis.com/token",
+              data=body,
+              headers={"Content-Type": "application/x-www-form-urlencoded"},
+              method="POST",
+          )
+          with urllib.request.urlopen(req, timeout=30) as resp:
+              token = json.loads(resp.read().decode("utf-8"))["access_token"]
+          print(token)
+          PY
+          )
           SITE_ENCODED=$(python -c 'import urllib.parse; print(urllib.parse.quote("${{ env.SITE_URL }}/", safe=""))')
           SITEMAP_ENCODED=$(python -c 'import urllib.parse; print(urllib.parse.quote("${{ env.SITEMAP_URL }}", safe=""))')
           curl --fail-with-body -sS -X PUT \


### PR DESCRIPTION
## Summary
- replace google-github-actions/auth with direct service account JWT OAuth flow
- submit the sitemap to Google Search Console without requiring IAM Service Account Credentials API

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/submit-urls.yml"); puts "yaml ok"'