### PR TITLE
Add AdSense account meta tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-MQ58ZKV2');</script>
 <!-- End Google Tag Manager -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/439c49a4efb78045d80bf9f0/script.js"></script> <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+    <meta name="google-adsense-account" content="ca-pub-3409938612356670">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="canonical" href="{{ blogBase['canonicalUrl'] }}" />


### PR DESCRIPTION
## Summary
- add the new AdSense account meta tag for ca-pub-3409938612356670
- keep ad display disabled; no adsbygoogle script is added before approval

## Verification
- confirmed no futuremedia/futuremediia domain references remain
- confirmed AdSense references use pub-3409938612356670