### PR TITLE
Improve SEO metadata and newsletter foundation

### DIFF
--- a/Gmeek.py
+++ b/Gmeek.py
@@ -98,7 +98,7 @@ class GMEEK:
     def defaultConfig(self):
         with open('config.json', 'r', encoding='utf-8') as f:
             config = json.load(f)
-        dconfig={"singlePage":[],"hiddenPage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","author":"白来","xName":"莫白来","xHandle":"wiselyfreely","xUrl":"https://x.com/wiselyfreely","enableAds":0}
+        dconfig={"singlePage":[],"hiddenPage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","author":"白来","xName":"莫白来","xHandle":"wiselyfreely","xUrl":"https://x.com/wiselyfreely","enableAds":0,"subscribeApiUrl":"","turnstileSiteKey":""}
 
         self.blogBase={**dconfig,**config}
         self.blogBase["postListJson"]={}
@@ -183,6 +183,11 @@ class GMEEK:
         render_dict.update(issue_data)
         render_dict["postBody"] = self.markdown2html(raw_md_content)
         render_dict["canonicalUrl"] = issue_data["postUrl"]
+        primary_label = issue_data["labels"][0] if issue_data.get("labels") else ""
+        if primary_label and primary_label not in self.blogBase["singlePage"] and primary_label not in self.blogBase["hiddenPage"]:
+            render_dict["primaryLabelUrl"] = f"{self.blogBase['homeUrl']}/{Pinyin().get_pinyin(primary_label)}.html"
+        else:
+            render_dict["primaryLabelUrl"] = self.blogBase["homeUrl"]
 
         if issue_data["labels"][0] in self.blogBase["singlePage"]:
             render_dict["bottomText"]=''

--- a/SEO_ADSENSE_NEWSLETTER.md
+++ b/SEO_ADSENSE_NEWSLETTER.md
@@ -1,0 +1,35 @@
+# SEO, AdSense, and Newsletter Checklist
+
+## 已在代码中完成
+
+- 全站保留 AdSense 账号 meta，不加载自动广告脚本。
+- 全站增加搜索引擎 robots meta。
+- 首页/列表页增加 `CollectionPage` 结构化数据。
+- 文章页使用 `BlogPosting` 结构化数据，并补充栏目、关键词、作者、发布和更新时间。
+- 订阅页改为可接入真实后端的表单，提交到 `config.json` 的 `subscribeApiUrl`。
+- 新增 Cloudflare Worker 订阅后端样板，支持确认订阅和退订。
+
+## AdSense 审核前不要做
+
+- 不要启用 `adsbygoogle.js` 自动广告脚本。
+- 不要放空广告位或占位广告卡片。
+- 不要批量生成低质量短文来填页面。
+
+## AdSense 审核前建议继续做
+
+- 继续清理旧品牌、旧栏目、重复标题和薄内容。
+- 保持关于本站、隐私政策、服务条款、免责声明、订阅页可访问。
+- 确保首页、栏目页、文章页在移动端可读。
+- 每个主要栏目至少保留一批稳定、原创、主题一致的文章。
+
+## 邮件订阅上线步骤
+
+1. 到 Cloudflare Turnstile 创建站点，域名填 `www.790427.xyz`。
+2. 把 Turnstile site key 写入根目录 `config.json` 的 `turnstileSiteKey`。
+3. 在 `workers/newsletter` 创建 D1，并把 `database_id` 写入 `wrangler.jsonc`。
+4. 用 `schema.sql` 初始化 D1。
+5. 在 Resend 或 SES 验证发信域名，配置 SPF/DKIM/DMARC。
+6. 用 Wrangler 设置 `RESEND_API_KEY` 和 `TURNSTILE_SECRET`。
+7. 部署 Worker，确认 `/api/subscribe` 路由生效。
+8. 把根目录 `config.json` 的 `subscribeApiUrl` 改为 `https://www.790427.xyz/api/subscribe`。
+9. 发送一次测试订阅，确认收到邮件、确认链接、退订链接都可用。

--- a/config.json
+++ b/config.json
@@ -15,6 +15,8 @@
 "xHandle":"wiselyfreely",
 "xUrl":"https://x.com/wiselyfreely",
 "enableAds":0,
+"subscribeApiUrl":"",
+"turnstileSiteKey":"",
 "startSite":"6/4/2025",
 "onePageListNum":15,
 "singlePage":["about","link"],

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <meta name="google-adsense-account" content="ca-pub-3409938612356670">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
     <link rel="canonical" href="{{ blogBase['canonicalUrl'] }}" />
     {{ blogBase['primerCSS'] }}
     {{ blogBase['allHead'] }}
@@ -52,21 +53,39 @@ var _hmt = _hmt || [];
 {
     "@context": "https://schema.org",
     "@type": "WebSite",
-    "name": "{{ blogBase.title }}",
-    "url": "{{ blogBase.homeUrl }}",
+    "name": {{ blogBase.title|tojson }},
+    "alternateName": {{ blogBase.subTitle|tojson }},
+    "url": {{ blogBase.homeUrl|tojson }},
+    "inLanguage": "zh-CN",
     "publisher": {
         "@type": "Person",
-        "name": "{{ blogBase.author }}",
-        "url": "{{ blogBase.xUrl }}"
+        "name": {{ blogBase.author|tojson }},
+        "url": {{ blogBase.xUrl|tojson }},
+        "sameAs": [
+            {{ blogBase.xUrl|tojson }}
+        ]
     },
     "potentialAction": {
         "@type": "SearchAction",
         "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "{{ blogBase.homeUrl }}/tag.html?q={search_term_string}"
+            "urlTemplate": {{ (blogBase.homeUrl + "/tag.html?q={search_term_string}")|tojson }}
         },
         "query-input": "required name=search_term_string"
     }
+}
+</script>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": {{ blogBase.author|tojson }},
+    "alternateName": {{ blogBase.xName|tojson }},
+    "url": {{ blogBase.homeUrl|tojson }},
+    "email": {{ ("mailto:" ~ blogBase.email)|tojson }},
+    "sameAs": [
+        {{ blogBase.xUrl|tojson }}
+    ]
 }
 </script>
 </head>

--- a/templates/plist.html
+++ b/templates/plist.html
@@ -7,6 +7,21 @@
 <meta property="og:url" content="{{ blogBase['homeUrl'] }}">
 <meta property="og:image" content="{{ blogBase['ogImage'] }}">
 <title>{{ blogBase['title'] }}</title>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": {{ blogBase.title|tojson }},
+    "description": {{ blogBase.subTitle|tojson }},
+    "url": {{ blogBase.canonicalUrl|tojson }},
+    "inLanguage": "zh-CN",
+    "isPartOf": {
+        "@type": "WebSite",
+        "name": {{ blogBase.title|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }}
+    }
+}
+</script>
 {% endblock %}
 
 {% block style %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -19,30 +19,38 @@
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",
-    "@type": "Article",
-    "headline": "{{ blogBase.postTitle }}",
-    "image": "{{ blogBase.ogImage }}",
-    "datePublished": "{{ blogBase.isoDate }}",
-    "dateModified": "{{ blogBase.updatedIsoDate|default(blogBase.isoDate) }}",
+    "@type": "BlogPosting",
+    "headline": {{ blogBase.postTitle|tojson }},
+    "description": {{ blogBase.description|tojson }},
+    "image": [
+        {{ blogBase.ogImage|tojson }}
+    ],
+    "datePublished": {{ blogBase.isoDate|tojson }},
+    "dateModified": {{ blogBase.updatedIsoDate|default(blogBase.isoDate)|tojson }},
+    "articleSection": {{ (blogBase.labels[0] if blogBase.labels else '文章')|tojson }},
+    "keywords": {{ blogBase.labels|join(',')|tojson }},
+    "inLanguage": "zh-CN",
     "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": "{{ blogBase.postUrl }}"
+        "@id": {{ blogBase.postUrl|tojson }}
     },
     "author": {
         "@type": "Person",
-        "name": "{{ blogBase.author }}",
-        "url": "{{ blogBase.xUrl }}"
+        "name": {{ blogBase.author|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }},
+        "sameAs": [
+            {{ blogBase.xUrl|tojson }}
+        ]
     },
     "publisher": {
-        "@type": "Person",
-        "name": "{{ blogBase.title }}",
+        "@type": "Organization",
+        "name": {{ blogBase.title|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }},
         "logo": {
             "@type": "ImageObject",
-            "url": "{{ blogBase.faviconUrl }}"
+            "url": {{ (blogBase.homeUrl + blogBase.faviconUrl if blogBase.faviconUrl.startswith('/') else blogBase.faviconUrl)|tojson }}
         }
-
-    },
-    "description": "{{ blogBase.description }}"
+    }
 }
 </script>
 <script type="application/ld+json">
@@ -53,19 +61,20 @@
         {
             "@type": "ListItem",
             "position": 1,
-            "name": "{{ blogBase.title }}",
-            "item": "{{ blogBase.homeUrl }}"
+            "name": {{ blogBase.title|tojson }},
+            "item": {{ blogBase.homeUrl|tojson }}
         },
         {
             "@type": "ListItem",
             "position": 2,
-            "name": "{{ blogBase.labels[0] if blogBase.labels else '文章' }}"
+            "name": {{ (blogBase.labels[0] if blogBase.labels else '文章')|tojson }},
+            "item": {{ blogBase.primaryLabelUrl|tojson }}
         },
         {
             "@type": "ListItem",
             "position": 3,
-            "name": "{{ blogBase.postTitle }}",
-            "item": "{{ blogBase.postUrl }}"
+            "name": {{ blogBase.postTitle|tojson }},
+            "item": {{ blogBase.postUrl|tojson }}
         }
     ]
 }

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -10,6 +10,28 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
 <title>邮件订阅 - {{ blogBase['title'] }}</title>
+{% if blogBase['turnstileSiteKey'] %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": {{ ("邮件订阅 - " ~ blogBase.title)|tojson }},
+    "description": "订阅白来关于职场、投资、读书与修行的新文章。",
+    "url": {{ (blogBase.homeUrl ~ "/subscribe.html")|tojson }},
+    "inLanguage": "zh-CN",
+    "isPartOf": {
+        "@type": "WebSite",
+        "name": {{ blogBase.title|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }}
+    },
+    {% if blogBase.subscribeApiUrl %},
+    "potentialAction": {
+        "@type": "SubscribeAction",
+        "target": {{ blogBase.subscribeApiUrl|tojson }}
+    }
+    {% endif %}
+}
+</script>
 {% endblock %}
 
 {% block style %}
@@ -20,13 +42,19 @@
 .subscribe-wrap{max-width:720px;margin:0 auto;}
 .subscribe-lead{font-size:18px;line-height:1.7;color:var(--color-fg-muted);margin:0 0 24px;}
 .subscribe-panel{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:24px;background:var(--color-canvas-subtle);}
-.subscribe-form{display:flex;gap:10px;flex-wrap:wrap;margin:18px 0 10px;}
+.subscribe-form{display:grid;grid-template-columns:1fr auto;gap:10px;margin:18px 0 10px;}
 .subscribe-form input{flex:1;min-width:240px;padding:10px 12px;border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;background:var(--color-canvas-default);color:var(--color-fg-default);}
 .subscribe-form a,.subscribe-form button{padding:10px 16px;border-radius:6px;border:1px solid var(--color-accent-emphasis,#0969da);background:var(--color-accent-emphasis,#0969da);color:#fff!important;text-decoration:none;cursor:pointer;}
+.subscribe-form button[disabled]{opacity:.65;cursor:not-allowed;}
+.turnstile-row,.subscribe-status{grid-column:1/-1;}
+.subscribe-status{display:none;padding:10px 12px;border-radius:6px;font-size:14px;line-height:1.5;}
+.subscribe-status.success{display:block;background:#dafbe1;color:#1a7f37;border:1px solid #aceebb;}
+.subscribe-status.error{display:block;background:#ffebe9;color:#cf222e;border:1px solid #ffcecb;}
+.subscribe-status.info{display:block;background:#ddf4ff;color:#0969da;border:1px solid #b6e3ff;}
 .subscribe-note{font-size:13px;color:var(--color-fg-muted);line-height:1.6;margin:10px 0 0;}
 .subscribe-columns{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin-top:24px;}
 .subscribe-columns a{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:12px;text-decoration:none;font-weight:600;text-align:center;}
-@media (max-width: 700px){.subscribe-columns{grid-template-columns:repeat(2,minmax(0,1fr));}.subscribe-form input{min-width:100%;}}
+@media (max-width: 700px){.subscribe-columns{grid-template-columns:repeat(2,minmax(0,1fr));}.subscribe-form{grid-template-columns:1fr;}.subscribe-form input{min-width:100%;}}
 </style>
 {% endblock %}
 
@@ -47,12 +75,18 @@
     <p class="subscribe-lead">少一点噪音，多一点能留下来的判断。这里会更新白来关于职场、投资、读书与修行的长文与阶段性札记。</p>
     <section class="subscribe-panel">
         <h2>收到新文章提醒</h2>
-        <p>正式邮件服务接入前，可以先用邮箱联系订阅；后续会替换为自动订阅表单，并保留退订入口。</p>
-        <form class="subscribe-form" action="mailto:{{ blogBase['email'] }}" method="post" enctype="text/plain">
+        <p>留下邮箱后会收到一封确认邮件。确认后，只发送新文章和阶段性札记，每封邮件都会带退订入口。</p>
+        <form class="subscribe-form" id="subscribe-form" action="{{ blogBase['subscribeApiUrl'] }}" method="post">
             <input type="email" name="email" placeholder="你的邮箱" autocomplete="email" required>
+            {% if blogBase['turnstileSiteKey'] %}
+            <div class="turnstile-row">
+                <div class="cf-turnstile" data-sitekey="{{ blogBase['turnstileSiteKey'] }}"></div>
+            </div>
+            {% endif %}
             <button type="submit">订阅</button>
+            <div class="subscribe-status" id="subscribe-status" role="status" aria-live="polite"></div>
         </form>
-        <p class="subscribe-note">也可以直接写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，标题写“订阅人到中年”。</p>
+        <p class="subscribe-note">如果表单暂时不可用，也可以直接写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，标题写“订阅人到中年”。</p>
     </section>
     <nav class="subscribe-columns" aria-label="栏目">
         <a href="{{ blogBase['homeUrl'] }}/zhi-chang.html">职场</a>
@@ -66,5 +100,56 @@
 {% block script %}
 <script>
 document.getElementById("pathHome").setAttribute("d",IconList["home"]);
+
+(function(){
+    const form = document.getElementById('subscribe-form');
+    const statusBox = document.getElementById('subscribe-status');
+    if (!form || !statusBox) return;
+
+    function setStatus(type, message) {
+        statusBox.className = 'subscribe-status ' + type;
+        statusBox.textContent = message;
+    }
+
+    form.addEventListener('submit', async function(event) {
+        event.preventDefault();
+        const endpoint = form.getAttribute('action');
+        const email = form.email.value.trim();
+        const button = form.querySelector('button[type="submit"]');
+        if (!endpoint) {
+            setStatus('error', '订阅接口尚未配置，请先通过邮箱联系订阅。');
+            return;
+        }
+
+        const turnstileInput = form.querySelector('input[name="cf-turnstile-response"]');
+        const turnstileToken = turnstileInput ? turnstileInput.value : '';
+        button.disabled = true;
+        setStatus('info', '正在提交...');
+
+        try {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    email: email,
+                    source: window.location.href,
+                    turnstileToken: turnstileToken
+                })
+            });
+            const result = await response.json().catch(function(){ return {}; });
+            if (!response.ok) {
+                throw new Error(result.message || '提交失败，请稍后再试。');
+            }
+            setStatus('success', result.message || '确认邮件已发送，请去邮箱里完成确认。');
+            form.reset();
+            if (window.turnstile) window.turnstile.reset();
+        } catch (error) {
+            setStatus('error', error.message || '提交失败，请稍后再试。');
+            if (window.turnstile) window.turnstile.reset();
+        } finally {
+            button.disabled = false;
+        }
+    });
+})();
 </script>
 {% endblock %}

--- a/workers/newsletter/README.md
+++ b/workers/newsletter/README.md
@@ -1,0 +1,43 @@
+# Newsletter Worker
+
+这个 Worker 为 `www.790427.xyz` 提供自建邮件订阅接口：
+
+- `POST /api/subscribe`：写入 D1，并发送确认邮件
+- `GET /api/subscribe/confirm?token=...`：确认订阅
+- `GET /api/subscribe/unsubscribe?token=...`：退订
+
+## 首次配置
+
+1. 创建 D1：
+
+   ```bash
+   cd workers/newsletter
+   npx wrangler d1 create bailai_newsletter
+   ```
+
+2. 把命令返回的 `database_id` 填到 `wrangler.jsonc`。
+
+3. 初始化表：
+
+   ```bash
+   npx wrangler d1 execute bailai_newsletter --remote --file=./schema.sql
+   ```
+
+4. 设置密钥：
+
+   ```bash
+   npx wrangler secret put RESEND_API_KEY
+   npx wrangler secret put TURNSTILE_SECRET
+   ```
+
+5. 在 Cloudflare Turnstile 新建站点，把 site key 填到根目录 `config.json` 的 `turnstileSiteKey`。
+
+6. 部署：
+
+   ```bash
+   npx wrangler deploy
+   ```
+
+## 发信域名
+
+Resend/SES 等服务需要单独验证 `790427.xyz` 或子域名，并配置 SPF/DKIM/DMARC。验证完成前，确认邮件可能发不出去或进入垃圾箱。

--- a/workers/newsletter/package.json
+++ b/workers/newsletter/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bailai-newsletter-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --check src/index.js",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/workers/newsletter/schema.sql
+++ b/workers/newsletter/schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS subscribers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'unsubscribed')),
+  source TEXT,
+  confirm_token TEXT NOT NULL UNIQUE,
+  unsubscribe_token TEXT NOT NULL UNIQUE,
+  confirmed_at TEXT,
+  unsubscribed_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscribers_status ON subscribers(status);
+CREATE INDEX IF NOT EXISTS idx_subscribers_confirm_token ON subscribers(confirm_token);
+CREATE INDEX IF NOT EXISTS idx_subscribers_unsubscribe_token ON subscribers(unsubscribe_token);

--- a/workers/newsletter/src/index.js
+++ b/workers/newsletter/src/index.js
@@ -1,0 +1,251 @@
+const JSON_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'Cache-Control': 'no-store',
+};
+
+function corsHeaders(request) {
+  const origin = request.headers.get('Origin') || '';
+  const allowed = new Set([
+    'https://www.790427.xyz',
+    'https://790427.xyz',
+  ]);
+  return {
+    'Access-Control-Allow-Origin': allowed.has(origin) ? origin : 'https://www.790427.xyz',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+  };
+}
+
+function json(request, data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+  });
+}
+
+function html(body, status = 200) {
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+function normalizeEmail(email) {
+  return String(email || '').trim().toLowerCase();
+}
+
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length <= 254;
+}
+
+function newToken() {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[char]));
+}
+
+async function verifyTurnstile(request, env, token) {
+  if (env.REQUIRE_TURNSTILE !== 'true') return true;
+  if (!env.TURNSTILE_SECRET) return true;
+  if (!token) return false;
+
+  const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      secret: env.TURNSTILE_SECRET,
+      response: token,
+      remoteip: request.headers.get('CF-Connecting-IP') || undefined,
+      idempotency_key: crypto.randomUUID(),
+    }),
+  });
+  const result = await response.json();
+  return result.success === true;
+}
+
+async function sendEmail(env, { to, subject, html }) {
+  if (!env.RESEND_API_KEY) return { skipped: true };
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: env.MAIL_FROM,
+      to,
+      subject,
+      html,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Resend error ${response.status}: ${text}`);
+  }
+
+  return response.json();
+}
+
+function confirmEmailHtml(env, email, confirmToken, unsubscribeToken) {
+  const siteUrl = env.SITE_URL || 'https://www.790427.xyz';
+  const confirmUrl = `${siteUrl}/api/subscribe/confirm?token=${encodeURIComponent(confirmToken)}`;
+  const unsubscribeUrl = `${siteUrl}/api/subscribe/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`;
+  const siteName = escapeHtml(env.SITE_NAME || '人到中年');
+  const safeEmail = escapeHtml(email);
+  return `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.7;color:#24292f">
+      <h2>确认订阅《${siteName}》</h2>
+      <p>你好，${safeEmail}：</p>
+      <p>请点击下面的链接确认订阅。确认后，你会收到白来关于职场、投资、读书与修行的新文章提醒。</p>
+      <p><a href="${escapeHtml(confirmUrl)}" style="display:inline-block;background:#0969da;color:#fff;padding:10px 14px;border-radius:6px;text-decoration:none">确认订阅</a></p>
+      <p style="font-size:13px;color:#57606a">如果不是你本人操作，可以忽略这封邮件，或点击 <a href="${escapeHtml(unsubscribeUrl)}">退订</a>。</p>
+    </div>
+  `;
+}
+
+async function subscribe(request, env) {
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return json(request, { message: '请求格式不正确。' }, 400);
+  }
+
+  const email = normalizeEmail(payload.email);
+  const name = String(payload.name || '').trim().slice(0, 80) || null;
+  const source = String(payload.source || '').trim().slice(0, 500) || null;
+
+  if (!isValidEmail(email)) {
+    return json(request, { message: '邮箱格式不正确。' }, 400);
+  }
+
+  const passedTurnstile = await verifyTurnstile(request, env, payload.turnstileToken);
+  if (!passedTurnstile) {
+    return json(request, { message: '验证失败，请刷新页面后重试。' }, 403);
+  }
+
+  const existing = await env.DB.prepare(
+    'SELECT email, status, confirm_token, unsubscribe_token FROM subscribers WHERE email = ?'
+  ).bind(email).first();
+
+  if (existing && existing.status === 'active') {
+    return json(request, { message: '这个邮箱已经订阅。' });
+  }
+
+  const confirmToken = existing?.confirm_token || newToken();
+  const unsubscribeToken = existing?.unsubscribe_token || newToken();
+
+  await env.DB.prepare(`
+    INSERT INTO subscribers (email, name, status, source, confirm_token, unsubscribe_token, updated_at)
+    VALUES (?, ?, 'pending', ?, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(email) DO UPDATE SET
+      name = excluded.name,
+      status = 'pending',
+      source = excluded.source,
+      confirm_token = excluded.confirm_token,
+      unsubscribe_token = excluded.unsubscribe_token,
+      updated_at = CURRENT_TIMESTAMP
+  `).bind(email, name, source, confirmToken, unsubscribeToken).run();
+
+  await sendEmail(env, {
+    to: email,
+    subject: `确认订阅《${env.SITE_NAME || '人到中年'}》`,
+    html: confirmEmailHtml(env, email, confirmToken, unsubscribeToken),
+  });
+
+  return json(request, { message: '确认邮件已发送，请去邮箱里完成确认。' }, 202);
+}
+
+async function confirm(request, env, token) {
+  if (!token) return html(renderMessage(env, '确认链接无效', '缺少确认 token。'), 400);
+
+  const result = await env.DB.prepare(`
+    UPDATE subscribers
+    SET status = 'active', confirmed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+    WHERE confirm_token = ?
+  `).bind(token).run();
+
+  if (result.meta.changes === 0) {
+    return html(renderMessage(env, '确认链接无效', '没有找到对应的订阅记录。'), 404);
+  }
+
+  return html(renderMessage(env, '订阅已确认', '以后你会收到《人到中年》的新文章提醒。'));
+}
+
+async function unsubscribe(request, env, token) {
+  if (!token) return html(renderMessage(env, '退订链接无效', '缺少退订 token。'), 400);
+
+  const result = await env.DB.prepare(`
+    UPDATE subscribers
+    SET status = 'unsubscribed', unsubscribed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+    WHERE unsubscribe_token = ?
+  `).bind(token).run();
+
+  if (result.meta.changes === 0) {
+    return html(renderMessage(env, '退订链接无效', '没有找到对应的订阅记录。'), 404);
+  }
+
+  return html(renderMessage(env, '已退订', '这个邮箱不会再收到新文章提醒。'));
+}
+
+function renderMessage(env, title, message) {
+  const siteUrl = env.SITE_URL || 'https://www.790427.xyz';
+  const safeTitle = escapeHtml(title);
+  const safeMessage = escapeHtml(message);
+  const safeSiteName = escapeHtml(env.SITE_NAME || '人到中年');
+  const safeSiteUrl = escapeHtml(siteUrl);
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${safeTitle} - ${safeSiteName}</title>
+  <style>
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:680px;margin:48px auto;padding:0 20px;line-height:1.7;color:#24292f}
+    a{color:#0969da}
+  </style>
+</head>
+<body>
+  <h1>${safeTitle}</h1>
+  <p>${safeMessage}</p>
+  <p><a href="${safeSiteUrl}">返回首页</a></p>
+</body>
+</html>`;
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: corsHeaders(request) });
+    }
+
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/api/subscribe') {
+      return subscribe(request, env);
+    }
+    if (request.method === 'GET' && url.pathname === '/api/subscribe/confirm') {
+      return confirm(request, env, url.searchParams.get('token'));
+    }
+    if (request.method === 'GET' && url.pathname === '/api/subscribe/unsubscribe') {
+      return unsubscribe(request, env, url.searchParams.get('token'));
+    }
+
+    return json(request, { message: 'Not found' }, 404);
+  },
+};

--- a/workers/newsletter/wrangler.jsonc
+++ b/workers/newsletter/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "bailai-newsletter",
+  "main": "src/index.js",
+  "compatibility_date": "2026-07-10",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "www.790427.xyz/api/subscribe*",
+      "zone_name": "790427.xyz"
+    }
+  ],
+  "vars": {
+    "SITE_URL": "https://www.790427.xyz",
+    "SITE_NAME": "人到中年",
+    "MAIL_FROM": "人到中年 <service@790427.xyz>",
+    "REQUIRE_TURNSTILE": "true"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "bailai_newsletter",
+      "database_id": "replace-with-cloudflare-d1-database-id"
+    }
+  ],
+  "observability": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary
- improve site and article structured data for SEO and AdSense review readiness
- upgrade the subscribe page to a backend-ready email subscription form with mail fallback
- add a Cloudflare Worker + D1 newsletter backend template with confirm/unsubscribe flows
- update privacy policy source and backup for newsletter data handling
- keep AdSense display scripts disabled until approval

## Verification
- python3 -m json.tool config.json
- PYTHONPYCACHEPREFIX=/private/tmp/python-pycache python3 -m py_compile Gmeek.py
- node --check workers/newsletter/src/index.js
- node -e "import('./workers/newsletter/src/index.js').then(m=>console.log(typeof m.default.fetch))"
- git diff --check