### PR TITLE
Configure Turnstile for newsletter form

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
 "xUrl":"https://x.com/wiselyfreely",
 "enableAds":0,
 "subscribeApiUrl":"",
-"turnstileSiteKey":"",
+"turnstileSiteKey":"0x4AAAAAADy7m99tTX6ix-52",
 "startSite":"6/4/2025",
 "onePageListNum":15,
 "singlePage":["about","link"],

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -80,7 +80,7 @@
             <input type="email" name="email" placeholder="你的邮箱" autocomplete="email" required>
             {% if blogBase['turnstileSiteKey'] %}
             <div class="turnstile-row">
-                <div class="cf-turnstile" data-sitekey="{{ blogBase['turnstileSiteKey'] }}"></div>
+                <div class="cf-turnstile" data-sitekey="{{ blogBase['turnstileSiteKey'] }}" data-action="turnstile-spin-v1"></div>
             </div>
             {% endif %}
             <button type="submit">订阅</button>

--- a/workers/newsletter/README.md
+++ b/workers/newsletter/README.md
@@ -30,7 +30,7 @@
    npx wrangler secret put TURNSTILE_SECRET
    ```
 
-5. 在 Cloudflare Turnstile 新建站点，把 site key 填到根目录 `config.json` 的 `turnstileSiteKey`。
+5. 在 Cloudflare Turnstile 新建站点，把 site key 填到根目录 `config.json` 的 `turnstileSiteKey`。当前站点已配置 Turnstile site key，secret key 只应通过 Wrangler secret 保存，不要写入仓库。
 
 6. 部署：
 

--- a/workers/newsletter/src/index.js
+++ b/workers/newsletter/src/index.js
@@ -60,7 +60,9 @@ function escapeHtml(value) {
 
 async function verifyTurnstile(request, env, token) {
   if (env.REQUIRE_TURNSTILE !== 'true') return true;
-  if (!env.TURNSTILE_SECRET) return true;
+  if (!env.TURNSTILE_SECRET) {
+    throw new Error('TURNSTILE_SECRET is not configured');
+  }
   if (!token) return false;
 
   const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
@@ -78,7 +80,9 @@ async function verifyTurnstile(request, env, token) {
 }
 
 async function sendEmail(env, { to, subject, html }) {
-  if (!env.RESEND_API_KEY) return { skipped: true };
+  if (!env.RESEND_API_KEY) {
+    throw new Error('RESEND_API_KEY is not configured');
+  }
 
   const response = await fetch('https://api.resend.com/emails', {
     method: 'POST',
@@ -135,10 +139,14 @@ async function subscribe(request, env) {
     return json(request, { message: '邮箱格式不正确。' }, 400);
   }
 
-  const passedTurnstile = await verifyTurnstile(request, env, payload.turnstileToken);
-  if (!passedTurnstile) {
-    return json(request, { message: '验证失败，请刷新页面后重试。' }, 403);
+  let passedTurnstile;
+  try {
+    passedTurnstile = await verifyTurnstile(request, env, payload.turnstileToken);
+  } catch (error) {
+    console.error(error);
+    return json(request, { message: '订阅服务尚未完成安全配置。' }, 503);
   }
+  if (!passedTurnstile) return json(request, { message: '验证失败，请刷新页面后重试。' }, 403);
 
   const existing = await env.DB.prepare(
     'SELECT email, status, confirm_token, unsubscribe_token FROM subscribers WHERE email = ?'
@@ -163,11 +171,16 @@ async function subscribe(request, env) {
       updated_at = CURRENT_TIMESTAMP
   `).bind(email, name, source, confirmToken, unsubscribeToken).run();
 
-  await sendEmail(env, {
-    to: email,
-    subject: `确认订阅《${env.SITE_NAME || '人到中年'}》`,
-    html: confirmEmailHtml(env, email, confirmToken, unsubscribeToken),
-  });
+  try {
+    await sendEmail(env, {
+      to: email,
+      subject: `确认订阅《${env.SITE_NAME || '人到中年'}》`,
+      html: confirmEmailHtml(env, email, confirmToken, unsubscribeToken),
+    });
+  } catch (error) {
+    console.error(error);
+    return json(request, { message: '订阅记录已保存，但确认邮件暂时无法发送。' }, 503);
+  }
 
   return json(request, { message: '确认邮件已发送，请去邮箱里完成确认。' }, 202);
 }


### PR DESCRIPTION
## Summary
- add the Cloudflare Turnstile site key to the newsletter form config
- add Turnstile action metadata to the subscribe widget
- make the newsletter Worker fail closed when Turnstile or email delivery secrets are missing
- document that the Turnstile secret must remain a Worker secret and not be committed

## Notes
- The Turnstile secret key was not written to the repository.
- subscribeApiUrl remains disabled until the Cloudflare Worker, D1 database, and email delivery secret are configured.

## Verification
- python3 -m json.tool config.json
- node --check workers/newsletter/src/index.js
- node -e "import('./workers/newsletter/src/index.js').then(m=>console.log(typeof m.default.fetch))"
- git diff --check