### PR TITLE
Preserve custom issue keywords in article schema

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -28,7 +28,7 @@
     "datePublished": {{ blogBase.isoDate|tojson }},
     "dateModified": {{ blogBase.updatedIsoDate|default(blogBase.isoDate)|tojson }},
     "articleSection": {{ (blogBase.labels[0] if blogBase.labels else '文章')|tojson }},
-    "keywords": {{ blogBase.labels|join(',')|tojson }},
+    "keywords": {{ (blogBase.keywords or (blogBase.labels|join(',')))|tojson }},
     "inLanguage": "zh-CN",
     "mainEntityOfPage": {
         "@type": "WebPage",


### PR DESCRIPTION
## Summary
- keep article JSON-LD keywords aligned with issue-level custom keywords
- fall back to labels only when no custom keywords are configured

## Validation
- PYTHONPYCACHEPREFIX=/private/tmp/python-pycache python3 -m py_compile Gmeek.py
- python3 -m json.tool config.json
- node --check workers/newsletter/src/index.js
- simulated issue trailing ##{...} metadata parsing for ogImage, keywords, timestamp, password, quote