### PR TITLE
Remove GTM and update Clarity tracking

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
 <html data-color-mode="light" data-dark-theme="{{ blogBase['nightTheme'] }}" data-light-theme="{{ blogBase['dayTheme'] }}" lang={% if blogBase['i18n']=='CN' %}"zh-CN"{% elif blogBase['i18n']=='RU' %}"ru"{% else -%}"en"{%- endif -%}>
 <head>
-  <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MQ58ZKV2');</script>
-<!-- End Google Tag Manager -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/439c49a4efb78045d80bf9f0/script.js"></script> <meta content="text/html; charset=utf-8" http-equiv="content-type" />
     <meta name="google-adsense-account" content="ca-pub-3409938612356670">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
@@ -35,9 +28,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script type="text/javascript">
     (function(c,l,a,r,i,t,y){
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-    })(window, document, "clarity", "script", "sh44c07wsg");
+    })(window, document, "clarity", "script", "xk8krek4hb");
 </script>
 <script src="https://unpkg.com/typeit@8.7.1/dist/index.umd.js"></script>
 <script type="application/ld+json">
@@ -158,10 +151,6 @@ body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;
 {% block style %}{% endblock %}
 
 <body>
-  <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MQ58ZKV2"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
     <header id="header" class="page-header">
         <nav class="header-nav-menu">
             <a href="{{ blogBase['homeUrl'] }}/">首页</a>

--- a/templates/includes/custom_head.html
+++ b/templates/includes/custom_head.html
@@ -9,9 +9,9 @@
 <script type="text/javascript">
     (function(c,l,a,r,i,t,y){
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-    })(window, document, "clarity", "script", "sh44c07wsg");
+    })(window, document, "clarity", "script", "xk8krek4hb");
 </script>
 
 <!-- 为自定义页面加载 Tailwind CSS 和 Inter 字体 -->


### PR DESCRIPTION
## Summary
- remove Google Tag Manager from the base template
- keep the GA4 gtag measurement ID for 790427.xyz
- update Clarity tracking to the new project ID

## Tests
- git diff --check
- rendered templates/404.html with Jinja smoke test