### PR TITLE
Add site positioning landing pages

### DIFF
--- a/Gmeek.py
+++ b/Gmeek.py
@@ -440,6 +440,9 @@ class GMEEK:
         add_url(self.blogBase["homeUrl"], priority="1.0", changefreq="daily")
         add_url(f"{self.blogBase['homeUrl']}/tag.html", priority="0.7")
         add_url(f"{self.blogBase['homeUrl']}/subscribe.html", priority="0.7")
+        add_url(f"{self.blogBase['homeUrl']}/about.html", priority="0.8")
+        add_url(f"{self.blogBase['homeUrl']}/start.html", priority="0.8")
+        add_url(f"{self.blogBase['homeUrl']}/ai-jiao-xue.html", priority="0.8")
 
         for page in self.blogBase["singeListJson"].values():
             if page["createdAt"] <= current_time:
@@ -568,6 +571,23 @@ class GMEEK:
         }
         self.renderHtml('subscribe.html', context, f"{self.root_dir}subscribe.html")
 
+    def createStaticLandingPages(self):
+        print("====== create static landing pages ======")
+        pages = [
+            ("about.html", "about.html"),
+            ("start.html", "start.html"),
+            ("ai-guide.html", "ai-jiao-xue.html"),
+        ]
+        for template_name, output_name in pages:
+            render_dict = self.blogBase.copy()
+            render_dict["canonicalUrl"] = f"{self.blogBase['homeUrl']}/{output_name}"
+            context = {
+                'blogBase': render_dict,
+                'i18n': self.i18n,
+                'IconList': IconBase
+            }
+            self.renderHtml(template_name, context, f"{self.root_dir}{output_name}")
+
     def createNotFoundPage(self):
         print("====== create 404 page ======")
         render_dict = self.blogBase.copy()
@@ -600,6 +620,7 @@ class GMEEK:
         self.createTagCloudPage()
         self.createTagPages()
         self.createSubscribePage()
+        self.createStaticLandingPages()
         self.createNotFoundPage()
         self.createFeedXml()
         self.createSitemapXml()
@@ -632,6 +653,7 @@ class GMEEK:
             self.createTagCloudPage()
             self.createTagPages()
             self.createSubscribePage()
+            self.createStaticLandingPages()
             self.createNotFoundPage()
             self.createFeedXml()
             self.createSitemapXml()

--- a/config.json
+++ b/config.json
@@ -37,7 +37,7 @@
 "indexScript":"",
 "showPostSource":0,
 "rssSplit":"sentence",
-"bottomText":"文章皆为原创，转载文章请注明出处。关注莫白来，愿你没白来。",
+"bottomText":"文章皆为原创，转载文章请注明出处。人到中年，记录读书、投资、AI 和生活实操。愿你没白来。",
 "primerCSS":"<link href='https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/Primer/21.0.7/primer.css' rel='stylesheet' />",
 "needComment":0
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -2,7 +2,7 @@
 
 {% block head %}
 <meta name="robots" content="noindex,follow">
-<meta name="description" content="页面不存在，返回人到中年继续阅读职场、投资、读书与修行内容。">
+<meta name="description" content="页面不存在，返回人到中年继续阅读人生、投资、读书与 AI 教学内容。">
 <meta property="og:title" content="页面不存在 - {{ blogBase['title'] }}">
 <meta property="og:description" content="这页暂时没有内容，回到人到中年继续阅读。">
 <meta property="og:type" content="website">
@@ -42,10 +42,11 @@
     <p class="not-found-copy">这页可能已经移动、删除，或者还没写出来。先回到能继续往前走的地方。</p>
     <nav class="not-found-actions" aria-label="404 导航">
         <a href="{{ blogBase['homeUrl'] }}/">首页</a>
-        <a href="{{ blogBase['homeUrl'] }}/zhi-chang.html">职场</a>
+        <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
+        <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">人生</a>
         <a href="{{ blogBase['homeUrl'] }}/tou-zi.html">投资</a>
         <a href="{{ blogBase['homeUrl'] }}/du-shu.html">读书</a>
-        <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">修行</a>
+        <a href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">AI 教学</a>
         <a href="{{ blogBase['homeUrl'] }}/tag.html">搜索</a>
     </nav>
 </main>

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,100 @@
+{% extends 'base.html' %}
+
+{% block head %}
+<meta name="description" content="关于人到中年与白来：记录读书、投资、AI 和生活实操，写给还想重新开始的人。">
+<meta property="og:title" content="关于本站 - {{ blogBase['title'] }}">
+<meta property="og:description" content="人到中年，重新学习如何生活、投资和使用技术。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ blogBase['homeUrl'] }}/about.html">
+<meta property="og:image" content="{{ blogBase['ogImage'] }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
+<title>关于本站 - {{ blogBase['title'] }}</title>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": {{ ("关于本站 - " ~ blogBase.title)|tojson }},
+    "description": "关于人到中年与白来：记录读书、投资、AI 和生活实操。",
+    "url": {{ (blogBase.homeUrl ~ "/about.html")|tojson }},
+    "inLanguage": "zh-CN",
+    "isPartOf": {
+        "@type": "WebSite",
+        "name": {{ blogBase.title|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }}
+    },
+    "author": {
+        "@type": "Person",
+        "name": {{ blogBase.author|tojson }},
+        "alternateName": {{ blogBase.xName|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }},
+        "email": {{ ("mailto:" ~ blogBase.email)|tojson }},
+        "sameAs": [{{ blogBase.xUrl|tojson }}]
+    }
+}
+</script>
+{% endblock %}
+
+{% block style %}
+<style>
+.page-title{margin:auto 0;font-weight:bold;}
+.title-right{display:flex;margin:auto 0 0 auto;}
+.title-right .circle{padding:14px 16px;margin-right:8px;}
+.content-page{max-width:760px;margin:0 auto;}
+.content-page h2{margin-top:28px;}
+.content-page p,.content-page li{font-size:16px;line-height:1.8;color:var(--color-fg-default);}
+.content-page .lead{font-size:19px;line-height:1.8;color:var(--color-fg-muted);margin-top:0;}
+.content-page ul{padding-left:22px;}
+.notice{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:14px 16px;background:var(--color-canvas-subtle);color:var(--color-fg-muted);}
+.page-links{display:flex;flex-wrap:wrap;gap:10px;margin-top:24px;}
+.page-links a{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:9px 13px;text-decoration:none;font-weight:600;}
+</style>
+{% endblock %}
+
+{% block header %}
+<h1 class="page-title">关于本站</h1>
+<div class="title-right">
+    <a href="{{ blogBase['homeUrl'] }}" id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
+        <svg class="octicon" width="16" height="16"><path id="pathHome" fill-rule="evenodd"></path></svg>
+    </a>
+    <a class="btn btn-invisible circle" onclick="modeSwitch();" title="{{ i18n['switchTheme'] }}" {%- if blogBase['themeMode']=='fix' -%}style="display:none;"{%- endif -%}>
+        <svg class="octicon" width="16" height="16"><path id="themeSwitch" fill-rule="evenodd"></path></svg>
+    </a>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="content-page">
+    <p class="lead">人到中年，是白来写给自己，也写给还想重新开始的人的个人网站。</p>
+    <p>这里不追逐热闹，也不制造焦虑。它记录三件事：读书和人生感悟，投资研判与实操复盘，以及面向中老年人的 iPhone 和 AI 操作教学。</p>
+
+    <h2>这个网站写什么</h2>
+    <ul>
+        <li>读书、人生下半场、关系、健康、心态和自我修正。</li>
+        <li>宏观观察、资产配置、投资实盘、风险控制和阶段复盘。</li>
+        <li>手机设置、防诈骗、ChatGPT、AI 工具和日常效率教程。</li>
+    </ul>
+
+    <h2>这个网站不写什么</h2>
+    <ul>
+        <li>不写没有验证过的暴富故事。</li>
+        <li>不把投资记录包装成确定性建议。</li>
+        <li>不为了流量故意制造恐惧、对立或羞辱。</li>
+    </ul>
+
+    <h2>联系与订阅</h2>
+    <p>你可以写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，也可以在 X 上关注 <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">{{ blogBase['xName'] }}</a>。</p>
+    <p class="notice">投资相关内容仅为个人研究、记录与复盘，不构成任何投资建议。请根据自己的风险承受能力独立判断。</p>
+    <div class="page-links">
+        <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
+        <a href="{{ blogBase['homeUrl'] }}/subscribe.html">邮件订阅</a>
+        <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">关注 X</a>
+    </div>
+</main>
+{% endblock %}
+
+{% block script %}
+<script>
+document.getElementById("pathHome").setAttribute("d",IconList["home"]);
+</script>
+{% endblock %}

--- a/templates/ai-guide.html
+++ b/templates/ai-guide.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+
+{% block head %}
+<meta name="description" content="中老年 iPhone 与 AI 教学入口：手机设置、防诈骗、ChatGPT、AI 工具和生活实操。">
+<meta property="og:title" content="iPhone 与 AI 教学 - {{ blogBase['title'] }}">
+<meta property="og:description" content="写给中老年人的手机和 AI 操作教学。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">
+<meta property="og:image" content="{{ blogBase['ogImage'] }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
+<title>iPhone 与 AI 教学 - {{ blogBase['title'] }}</title>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": {{ ("iPhone 与 AI 教学 - " ~ blogBase.title)|tojson }},
+    "description": "中老年 iPhone 与 AI 教学入口：手机设置、防诈骗、ChatGPT、AI 工具和生活实操。",
+    "url": {{ (blogBase.homeUrl ~ "/ai-jiao-xue.html")|tojson }},
+    "inLanguage": "zh-CN",
+    "isPartOf": {
+        "@type": "WebSite",
+        "name": {{ blogBase.title|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }}
+    }
+}
+</script>
+{% endblock %}
+
+{% block style %}
+<style>
+.page-title{margin:auto 0;font-weight:bold;}
+.title-right{display:flex;margin:auto 0 0 auto;}
+.title-right .circle{padding:14px 16px;margin-right:8px;}
+.guide-page{max-width:780px;margin:0 auto;}
+.guide-lead{font-size:19px;line-height:1.8;color:var(--color-fg-muted);margin:0 0 22px;}
+.guide-section{border-top:1px solid var(--borderColor-muted,var(--color-border-muted));padding-top:20px;margin-top:20px;}
+.guide-section h2{margin-top:0;}
+.guide-section p,.guide-section li{font-size:16px;line-height:1.8;}
+.guide-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:24px;}
+.guide-actions a{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:9px 13px;text-decoration:none;font-weight:600;}
+</style>
+{% endblock %}
+
+{% block header %}
+<h1 class="page-title">iPhone 与 AI 教学</h1>
+<div class="title-right">
+    <a href="{{ blogBase['homeUrl'] }}" id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
+        <svg class="octicon" width="16" height="16"><path id="pathHome" fill-rule="evenodd"></path></svg>
+    </a>
+    <a class="btn btn-invisible circle" onclick="modeSwitch();" title="{{ i18n['switchTheme'] }}" {%- if blogBase['themeMode']=='fix' -%}style="display:none;"{%- endif -%}>
+        <svg class="octicon" width="16" height="16"><path id="themeSwitch" fill-rule="evenodd"></path></svg>
+    </a>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="guide-page">
+    <p class="guide-lead">这个栏目写给中老年人，也写给想把手机和 AI 真正用进生活的人。目标不是炫技，而是让每一步都能照着做。</p>
+    <section class="guide-section">
+        <h2>会重点写什么</h2>
+        <ul>
+            <li>iPhone 基础设置：字体、相册、备忘录、健康、家人共享和账号安全。</li>
+            <li>防诈骗与隐私保护：陌生链接、支付安全、验证码、骚扰电话和密码管理。</li>
+            <li>AI 日常用法：用 ChatGPT 查资料、写消息、整理旅行计划、学习英语和做表格。</li>
+        </ul>
+    </section>
+    <section class="guide-section">
+        <h2>推荐文章标签</h2>
+        <p>后续发布教程时，建议统一使用 “AI教学” 或 “iPhone” 标签。等文章积累后，这个入口页会继续改成按系列导航。</p>
+        <div class="guide-actions">
+            <a href="{{ blogBase['homeUrl'] }}/tag.html#AI教学">AI 教学标签</a>
+            <a href="{{ blogBase['homeUrl'] }}/tag.html#iPhone">iPhone 标签</a>
+            <a href="{{ blogBase['homeUrl'] }}/subscribe.html">订阅教程更新</a>
+        </div>
+    </section>
+</main>
+{% endblock %}
+
+{% block script %}
+<script>
+document.getElementById("pathHome").setAttribute("d",IconList["home"]);
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -157,11 +157,13 @@ body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;
     <header id="header" class="page-header">
         <nav class="header-nav-menu">
             <a href="{{ blogBase['homeUrl'] }}/">首页</a>
-            <a href="{{ blogBase['homeUrl'] }}/zhi-chang.html">职场</a>
+            <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
+            <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">人生</a>
             <a href="{{ blogBase['homeUrl'] }}/tou-zi.html">投资</a>
             <a href="{{ blogBase['homeUrl'] }}/du-shu.html">读书</a>
-            <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">修行</a>
+            <a href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">AI 教学</a>
             <a href="{{ blogBase['homeUrl'] }}/subscribe.html">订阅</a>
+            <a href="{{ blogBase['homeUrl'] }}/about.html">关于</a>
             <a href="{{ blogBase['homeUrl'] }}/tag.html">搜索</a>
         </nav>
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,6 @@
 <div id="footer1" style="margin-top: 32px;">Copyright all reserved © <span id="copyrightYear"></span>-future <a href="{{ blogBase['homeUrl'] }}">{{ blogBase['title'] }}</a><br>
 <a href="https://www.790427.xyz/about.html">关于本站</a> |
+<a href="https://www.790427.xyz/start.html">从这里开始</a> |
 <a href="https://www.790427.xyz/subscribe.html">邮件订阅</a> |
 <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">X: {{ blogBase['xName'] }}</a> |
 <a href="https://www.790427.xyz/terms-of-service.html">服务条款</a> |

--- a/templates/plist.html
+++ b/templates/plist.html
@@ -40,6 +40,14 @@
 .listTitle{overflow:hidden;white-space:nowrap;text-overflow: ellipsis;max-width: 100%;}
 .listLabels{white-space:nowrap;display:flex;}
 .listLabels object{max-height:16px;max-width:24px;}
+.home-kicker{font-size:13px;font-weight:700;color:var(--color-accent-fg,#0969da);margin:0 0 8px;}
+.home-lead{font-size:18px;line-height:1.7;color:var(--color-fg-muted);margin:0 auto 22px;max-width:720px;text-align:center;}
+.home-tracks{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin:0 0 24px;}
+.home-track{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:16px;text-decoration:none;background:var(--color-canvas-default);}
+.home-track strong{display:block;font-size:16px;margin-bottom:8px;color:var(--color-fg-default);}
+.home-track span{display:block;font-size:14px;line-height:1.6;color:var(--color-fg-muted);}
+.home-actions{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin:0 0 28px;}
+.home-actions a{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:9px 13px;text-decoration:none;font-weight:600;}
 
 #animated-subtitle {
     min-height: 24px; /* 您可以根据字体大小调整 */
@@ -51,6 +59,7 @@
     .blogTitle{display:none;}
     #buttonRSS{display:none;}
     .LabelTime{display:none;}
+    .home-tracks{grid-template-columns:1fr;}
 }
 </style>
 {{ blogBase['indexStyle'] }}
@@ -106,6 +115,30 @@
 {% block content %}
 
 <div id="animated-subtitle" style="margin-bottom: 16px; text-align: center; font-style: italic;"></div>
+
+<section class="home-intro" aria-labelledby="home-intro-title">
+    <p class="home-kicker" id="home-intro-title" style="text-align:center;">人到中年，重新学习如何生活、投资和使用技术</p>
+    <p class="home-lead">这里记录白来的读书与人生感悟、投资研判与实操复盘，也写给中老年人的 iPhone 和 AI 操作教学。</p>
+    <div class="home-tracks">
+        <a class="home-track" href="{{ blogBase['homeUrl'] }}/xiu-xing.html">
+            <strong>人生与读书</strong>
+            <span>读书笔记、人生下半场、关系、健康、心态和自我修正。</span>
+        </a>
+        <a class="home-track" href="{{ blogBase['homeUrl'] }}/tou-zi.html">
+            <strong>投资研判</strong>
+            <span>宏观观察、资产配置、实盘记录、风险控制和阶段复盘。</span>
+        </a>
+        <a class="home-track" href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">
+            <strong>iPhone 与 AI 教学</strong>
+            <span>面向中老年人的手机设置、防诈骗、ChatGPT 和日常效率教程。</span>
+        </a>
+    </div>
+    <div class="home-actions">
+        <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
+        <a href="{{ blogBase['homeUrl'] }}/subscribe.html">邮件订阅</a>
+        <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">关注 {{ blogBase['xName'] }}</a>
+    </div>
+</section>
 
 <nav class="SideNav border">
 {# [ 关键修复 ] 

--- a/templates/post.html
+++ b/templates/post.html
@@ -179,6 +179,16 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px;
 }
+.investment-disclaimer {
+    margin: 24px 0 0;
+    padding: 14px 16px;
+    border: 1px solid var(--borderColor-muted, var(--color-border-muted));
+    border-radius: 6px;
+    background: var(--color-canvas-subtle);
+    color: var(--color-fg-muted);
+    font-size: 14px;
+    line-height: 1.7;
+}
 
 /* Password Overlay Styles */
 #password-overlay {
@@ -270,6 +280,12 @@
 </div>
 
 <div class="markdown-body" id="postBody">{{ blogBase['postBody']|safe }}</div>
+
+{% if '投资' in blogBase['labels'] %}
+<div class="investment-disclaimer">
+    本文仅为个人研究、记录与复盘，不构成任何投资建议。市场有风险，请根据自己的财务状况、风险承受能力和独立判断做决定。
+</div>
+{% endif %}
 
 <div class="post-footer">
     <div class="bottom-text-inline">{{ blogBase['bottomText'] }}</div>

--- a/templates/start.html
+++ b/templates/start.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+
+{% block head %}
+<meta name="description" content="从这里开始阅读人到中年：人生与读书、投资研判、iPhone 与 AI 教学三条主线。">
+<meta property="og:title" content="从这里开始 - {{ blogBase['title'] }}">
+<meta property="og:description" content="按人生、投资、AI 教学三条主线进入人到中年。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ blogBase['homeUrl'] }}/start.html">
+<meta property="og:image" content="{{ blogBase['ogImage'] }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
+<title>从这里开始 - {{ blogBase['title'] }}</title>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": {{ ("从这里开始 - " ~ blogBase.title)|tojson }},
+    "description": "按人生、投资、AI 教学三条主线进入人到中年。",
+    "url": {{ (blogBase.homeUrl ~ "/start.html")|tojson }},
+    "inLanguage": "zh-CN",
+    "isPartOf": {
+        "@type": "WebSite",
+        "name": {{ blogBase.title|tojson }},
+        "url": {{ blogBase.homeUrl|tojson }}
+    }
+}
+</script>
+{% endblock %}
+
+{% block style %}
+<style>
+.page-title{margin:auto 0;font-weight:bold;}
+.title-right{display:flex;margin:auto 0 0 auto;}
+.title-right .circle{padding:14px 16px;margin-right:8px;}
+.start-page{max-width:820px;margin:0 auto;}
+.start-lead{font-size:19px;line-height:1.8;color:var(--color-fg-muted);margin:0 0 24px;}
+.start-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin:20px 0 28px;}
+.start-card{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:18px;text-decoration:none;background:var(--color-canvas-default);}
+.start-card strong{display:block;font-size:18px;margin-bottom:10px;color:var(--color-fg-default);}
+.start-card span{display:block;font-size:14px;line-height:1.7;color:var(--color-fg-muted);}
+.start-list{border-top:1px solid var(--borderColor-muted,var(--color-border-muted));padding-top:20px;}
+.start-list h2{margin-top:0;}
+.start-list li{line-height:1.8;margin:8px 0;}
+.start-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:24px;}
+.start-actions a{border:1px solid var(--borderColor-muted,var(--color-border-muted));border-radius:6px;padding:9px 13px;text-decoration:none;font-weight:600;}
+@media (max-width: 760px){.start-grid{grid-template-columns:1fr;}}
+</style>
+{% endblock %}
+
+{% block header %}
+<h1 class="page-title">从这里开始</h1>
+<div class="title-right">
+    <a href="{{ blogBase['homeUrl'] }}" id="buttonHome" class="btn btn-invisible circle" title="{{ i18n['home'] }}">
+        <svg class="octicon" width="16" height="16"><path id="pathHome" fill-rule="evenodd"></path></svg>
+    </a>
+    <a class="btn btn-invisible circle" onclick="modeSwitch();" title="{{ i18n['switchTheme'] }}" {%- if blogBase['themeMode']=='fix' -%}style="display:none;"{%- endif -%}>
+        <svg class="octicon" width="16" height="16"><path id="themeSwitch" fill-rule="evenodd"></path></svg>
+    </a>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="start-page">
+    <p class="start-lead">如果你第一次来到这里，可以先按三条主线阅读：想重新理解自己，读人生与读书；想管好钱，读投资；想把手机和 AI 用起来，读教学。</p>
+    <section class="start-grid" aria-label="内容主线">
+        <a class="start-card" href="{{ blogBase['homeUrl'] }}/xiu-xing.html">
+            <strong>人生与读书</strong>
+            <span>给人生下半场留一点安静的判断力，记录读过的书、想通的事和还没想通的地方。</span>
+        </a>
+        <a class="start-card" href="{{ blogBase['homeUrl'] }}/tou-zi.html">
+            <strong>投资研判</strong>
+            <span>记录宏观、资产配置、实际操作和复盘。重视风险，少一点口号，多一点过程。</span>
+        </a>
+        <a class="start-card" href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">
+            <strong>iPhone 与 AI 教学</strong>
+            <span>写给中老年人，也写给需要把技术真正用进生活的人。</span>
+        </a>
+    </section>
+    <section class="start-list">
+        <h2>推荐阅读方式</h2>
+        <ul>
+            <li>先读一篇和你当下问题最接近的文章，不必从头补课。</li>
+            <li>投资内容重点看判断过程和风险清单，不把任何一篇文章当成买卖指令。</li>
+            <li>教学内容可以边看边做，遇到家人也需要的步骤，可以直接转给他们。</li>
+        </ul>
+        <div class="start-actions">
+            <a href="{{ blogBase['homeUrl'] }}/subscribe.html">订阅新文章</a>
+            <a href="{{ blogBase['homeUrl'] }}/tag.html">查看全部标签</a>
+            <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">关注 {{ blogBase['xName'] }}</a>
+        </div>
+    </section>
+</main>
+{% endblock %}
+
+{% block script %}
+<script>
+document.getElementById("pathHome").setAttribute("d",IconList["home"]);
+</script>
+{% endblock %}

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head %}
-<meta name="description" content="订阅人到中年，收到白来关于职场、投资、读书与修行的新文章。">
+<meta name="description" content="订阅人到中年，收到白来关于人生、读书、投资与 iPhone/AI 教学的新文章。">
 <meta property="og:title" content="邮件订阅 - {{ blogBase['title'] }}">
 <meta property="og:description" content="少一点噪音，多一点能留下来的判断。">
 <meta property="og:type" content="website">
@@ -16,7 +16,7 @@
     "@context": "https://schema.org",
     "@type": "WebPage",
     "name": {{ ("邮件订阅 - " ~ blogBase.title)|tojson }},
-    "description": "订阅白来关于职场、投资、读书与修行的新文章。",
+    "description": "订阅白来关于人生、读书、投资与 iPhone/AI 教学的新文章。",
     "url": {{ (blogBase.homeUrl ~ "/subscribe.html")|tojson }},
     "inLanguage": "zh-CN",
     "isPartOf": {
@@ -71,7 +71,7 @@
 
 {% block content %}
 <main class="subscribe-wrap">
-    <p class="subscribe-lead">少一点噪音，多一点能留下来的判断。这里会更新白来关于职场、投资、读书与修行的长文与阶段性札记。</p>
+    <p class="subscribe-lead">少一点噪音，多一点能留下来的判断。这里会更新白来关于人生、读书、投资与 iPhone/AI 教学的长文与阶段性札记。</p>
     <section class="subscribe-panel">
         <h2>收到新文章提醒</h2>
         <p>留下邮箱后会收到一封确认邮件。确认后，只发送新文章和阶段性札记，每封邮件都会带退订入口。</p>
@@ -88,10 +88,10 @@
         <p class="subscribe-note">如果表单暂时不可用，也可以直接写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，标题写“订阅人到中年”。</p>
     </section>
     <nav class="subscribe-columns" aria-label="栏目">
-        <a href="{{ blogBase['homeUrl'] }}/zhi-chang.html">职场</a>
+        <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">人生</a>
         <a href="{{ blogBase['homeUrl'] }}/tou-zi.html">投资</a>
         <a href="{{ blogBase['homeUrl'] }}/du-shu.html">读书</a>
-        <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">修行</a>
+        <a href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">AI 教学</a>
     </nav>
 </main>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add stable About, Start, and iPhone/AI teaching landing pages
- update homepage, navigation, subscription, footer, and 404 copy around the new positioning
- include static landing pages in sitemap generation
- add an automatic disclaimer for posts tagged 投资

## Tests
- git diff --check
- PYTHONPYCACHEPREFIX=/private/tmp/gmeek-pycache python3 -m py_compile Gmeek.py
- rendered plist/about/start/ai-guide/subscribe/404/post templates with a Jinja smoke test