### PR TITLE
Add weekly X and time inputs

### DIFF
--- a/.github/workflows/record-weekly-operations.yml
+++ b/.github/workflows/record-weekly-operations.yml
@@ -1,0 +1,98 @@
+name: Record Weekly Operations
+
+on:
+  workflow_dispatch:
+    inputs:
+      week_ending:
+        description: Week ending date (YYYY-MM-DD)
+        required: true
+        type: string
+      followers:
+        description: X followers at week end
+        required: true
+        type: number
+      posts_published:
+        description: X posts and threads published
+        required: true
+        type: number
+      impressions:
+        description: X impressions during the week
+        required: true
+        type: number
+      profile_visits:
+        description: X profile visits during the week
+        required: true
+        type: number
+      link_clicks:
+        description: X link clicks during the week
+        required: true
+        type: number
+      bookmarks:
+        description: X bookmarks during the week
+        required: true
+        type: number
+      replies:
+        description: X replies received during the week
+        required: true
+        type: number
+      reposts:
+        description: X reposts during the week
+        required: true
+        type: number
+      time_split:
+        description: Creation and interaction hours, for example 20,20
+        required: true
+        default: "20,20"
+        type: string
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    if: github.repository == 'neverasecond/granthuang999.github.io'
+    env:
+      OPS_ENDPOINT: https://www.790427.xyz/api/ops/weekly-input
+      NEWSLETTER_SEND_TOKEN: ${{ secrets.NEWSLETTER_SEND_TOKEN }}
+      WEEK_ENDING: ${{ inputs.week_ending }}
+      FOLLOWERS: ${{ inputs.followers }}
+      POSTS_PUBLISHED: ${{ inputs.posts_published }}
+      IMPRESSIONS: ${{ inputs.impressions }}
+      PROFILE_VISITS: ${{ inputs.profile_visits }}
+      LINK_CLICKS: ${{ inputs.link_clicks }}
+      BOOKMARKS: ${{ inputs.bookmarks }}
+      REPLIES: ${{ inputs.replies }}
+      REPOSTS: ${{ inputs.reposts }}
+      TIME_SPLIT: ${{ inputs.time_split }}
+    steps:
+      - name: Record private weekly totals
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, urllib.request
+
+          creation, interaction = [float(part.strip()) for part in os.environ["TIME_SPLIT"].split(",", 1)]
+          payload = {
+              "weekEnding": os.environ["WEEK_ENDING"],
+              "followers": int(os.environ["FOLLOWERS"]),
+              "postsPublished": int(os.environ["POSTS_PUBLISHED"]),
+              "impressions": int(os.environ["IMPRESSIONS"]),
+              "profileVisits": int(os.environ["PROFILE_VISITS"]),
+              "linkClicks": int(os.environ["LINK_CLICKS"]),
+              "bookmarks": int(os.environ["BOOKMARKS"]),
+              "replies": int(os.environ["REPLIES"]),
+              "reposts": int(os.environ["REPOSTS"]),
+              "creationHours": creation,
+              "interactionHours": interaction,
+          }
+          request = urllib.request.Request(
+              os.environ["OPS_ENDPOINT"],
+              data=json.dumps(payload).encode(),
+              headers={
+                  "Authorization": f"Bearer {os.environ['NEWSLETTER_SEND_TOKEN']}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              result = json.load(response)
+          print(json.dumps({"stored": bool(result.get("stored")), "weekEnding": result.get("weekEnding")}))
+          PY

--- a/operations/collect_metrics.py
+++ b/operations/collect_metrics.py
@@ -333,6 +333,27 @@ def collect_newsletter(metric_date: dt.date) -> list[Metric]:
     ]
 
 
+def collect_weekly_input() -> list[Metric]:
+    result = authorized_json("weekly-input")
+    week_ending = str(result.get("weekEnding") or "")
+    if not week_ending:
+        return []
+    x_fields = (
+        "followers", "postsPublished", "impressions", "profileVisits",
+        "linkClicks", "bookmarks", "replies", "reposts",
+    )
+    time_fields = ("creationHours", "interactionHours")
+    metrics = [
+        Metric("x_manual", field, float(result.get(field) or 0), metadata={"weekEnding": week_ending})
+        for field in x_fields
+    ]
+    metrics.extend(
+        Metric("operations_time", field, float(result.get(field) or 0), metadata={"weekEnding": week_ending})
+        for field in time_fields
+    )
+    return metrics
+
+
 def check_url(url: str) -> tuple[int, float, str]:
     started = time.monotonic()
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
@@ -412,6 +433,12 @@ def build_report(
     new_subscribers = find_metric(metrics, "newsletter", "createdYesterday")
     confirmed = find_metric(metrics, "newsletter", "confirmedYesterday")
     unsubscribed = find_metric(metrics, "newsletter", "unsubscribedYesterday")
+    x_followers = find_metric(metrics, "x_manual", "followers")
+    x_posts = find_metric(metrics, "x_manual", "postsPublished")
+    x_impressions = find_metric(metrics, "x_manual", "impressions")
+    x_bookmarks = find_metric(metrics, "x_manual", "bookmarks")
+    creation_hours = find_metric(metrics, "operations_time", "creationHours")
+    interaction_hours = find_metric(metrics, "operations_time", "interactionHours")
 
     prefix = "异常告警" if failures else ("月度运营报告" if report_mode == "monthly" else "每周运营报告")
     subject = f"{prefix}｜人到中年｜{metric_date.isoformat()}"
@@ -437,6 +464,16 @@ Google 搜索（稳定的最近28天窗口）
 - 昨日确认：{fmt_number(confirmed)}
 - 昨日退订：{fmt_number(unsubscribed)}
 
+X（最近一次周度人工录入）
+- 关注者：{fmt_number(x_followers)}
+- 发布数：{fmt_number(x_posts)}
+- 展示：{fmt_number(x_impressions)}
+- 收藏：{fmt_number(x_bookmarks)}
+
+时间投入（最近一周）
+- 创作：{fmt_number(creation_hours, 1)} 小时
+- 互动：{fmt_number(interaction_hours, 1)} 小时
+
 健康与采集问题
 {issue_lines}
 
@@ -453,6 +490,10 @@ Google 搜索（稳定的最近28天窗口）
       <ul><li>点击：{fmt_number(clicks)}</li><li>展示：{fmt_number(impressions)}</li><li>CTR：{fmt_number(ctr, 2)}%</li></ul>
       <h2 style="font-size:17px">邮件订阅</h2>
       <ul><li>有效订阅：{fmt_number(active_subscribers)}</li><li>待确认：{fmt_number(pending_subscribers)}</li><li>昨日新增：{fmt_number(new_subscribers)}</li><li>昨日确认：{fmt_number(confirmed)}</li><li>昨日退订：{fmt_number(unsubscribed)}</li></ul>
+      <h2 style="font-size:17px">X（最近一次周度人工录入）</h2>
+      <ul><li>关注者：{fmt_number(x_followers)}</li><li>发布数：{fmt_number(x_posts)}</li><li>展示：{fmt_number(x_impressions)}</li><li>收藏：{fmt_number(x_bookmarks)}</li></ul>
+      <h2 style="font-size:17px">时间投入（最近一周）</h2>
+      <ul><li>创作：{fmt_number(creation_hours, 1)} 小时</li><li>互动：{fmt_number(interaction_hours, 1)} 小时</li></ul>
       <h2 style="font-size:17px">健康与采集问题</h2><ul>{escaped_issues}</ul>
       <p style="font-size:13px;color:#57606a">X 数据暂不自动抓取，在周度复盘中人工补录。AdSense 批准前不采集收入。</p>
     </div>
@@ -494,6 +535,7 @@ def main() -> int:
         ("search_console", lambda: collect_search_console(token, metric_date)),
         ("clarity", collect_clarity),
         ("newsletter", lambda: collect_newsletter(metric_date)),
+        ("weekly_input", collect_weekly_input),
     )
     for source, collector in collectors:
         try:

--- a/operations/schema.sql
+++ b/operations/schema.sql
@@ -42,3 +42,18 @@ CREATE TABLE IF NOT EXISTS manual_x_metrics (
   notes TEXT,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS weekly_operations (
+  week_ending TEXT PRIMARY KEY,
+  followers INTEGER,
+  posts_published INTEGER,
+  impressions INTEGER,
+  profile_visits INTEGER,
+  link_clicks INTEGER,
+  bookmarks INTEGER,
+  replies INTEGER,
+  reposts INTEGER,
+  creation_hours REAL,
+  interaction_hours REAL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/workers/newsletter/src/index.js
+++ b/workers/newsletter/src/index.js
@@ -198,6 +198,22 @@ async function ensureOperationsSchema(env) {
       )
     `),
     env.OPS_DB.prepare(`
+      CREATE TABLE IF NOT EXISTS weekly_operations (
+        week_ending TEXT PRIMARY KEY,
+        followers INTEGER,
+        posts_published INTEGER,
+        impressions INTEGER,
+        profile_visits INTEGER,
+        link_clicks INTEGER,
+        bookmarks INTEGER,
+        replies INTEGER,
+        reposts INTEGER,
+        creation_hours REAL,
+        interaction_hours REAL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `),
+    env.OPS_DB.prepare(`
       CREATE INDEX IF NOT EXISTS idx_daily_metrics_source_date
       ON daily_metrics(source, metric_date)
     `),
@@ -359,6 +375,74 @@ async function sendOperationsReport(request, env) {
     text,
   });
   return json(request, { sent: true });
+}
+
+const WEEKLY_NUMBER_FIELDS = [
+  'followers', 'postsPublished', 'impressions', 'profileVisits', 'linkClicks',
+  'bookmarks', 'replies', 'reposts', 'creationHours', 'interactionHours',
+];
+
+async function weeklyOperations(request, env) {
+  if (request.method === 'GET') {
+    await ensureOperationsSchema(env);
+    const row = await env.OPS_DB.prepare(`
+      SELECT week_ending AS weekEnding, followers,
+             posts_published AS postsPublished, impressions,
+             profile_visits AS profileVisits, link_clicks AS linkClicks,
+             bookmarks, replies, reposts,
+             creation_hours AS creationHours,
+             interaction_hours AS interactionHours
+      FROM weekly_operations
+      ORDER BY week_ending DESC
+      LIMIT 1
+    `).first();
+    return json(request, row || {});
+  }
+
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return json(request, { message: '请求格式不正确。' }, 400);
+  }
+  const weekEnding = String(payload.weekEnding || '');
+  if (!validMetricDate(weekEnding)) {
+    return json(request, { message: 'weekEnding must use YYYY-MM-DD.' }, 400);
+  }
+  const values = {};
+  for (const field of WEEKLY_NUMBER_FIELDS) {
+    const value = Number(payload[field]);
+    if (!Number.isFinite(value) || value < 0) {
+      return json(request, { message: `Invalid weekly metric: ${field}` }, 400);
+    }
+    values[field] = value;
+  }
+
+  await ensureOperationsSchema(env);
+  await env.OPS_DB.prepare(`
+    INSERT INTO weekly_operations (
+      week_ending, followers, posts_published, impressions, profile_visits,
+      link_clicks, bookmarks, replies, reposts, creation_hours,
+      interaction_hours, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(week_ending) DO UPDATE SET
+      followers = excluded.followers,
+      posts_published = excluded.posts_published,
+      impressions = excluded.impressions,
+      profile_visits = excluded.profile_visits,
+      link_clicks = excluded.link_clicks,
+      bookmarks = excluded.bookmarks,
+      replies = excluded.replies,
+      reposts = excluded.reposts,
+      creation_hours = excluded.creation_hours,
+      interaction_hours = excluded.interaction_hours,
+      updated_at = CURRENT_TIMESTAMP
+  `).bind(
+    weekEnding, values.followers, values.postsPublished, values.impressions,
+    values.profileVisits, values.linkClicks, values.bookmarks, values.replies,
+    values.reposts, values.creationHours, values.interactionHours,
+  ).run();
+  return json(request, { stored: true, weekEnding });
 }
 
 function postNotificationHtml(env, post, subscriber) {
@@ -687,6 +771,9 @@ export default {
       }
       if (request.method === 'POST' && url.pathname === '/api/ops/report') {
         return sendOperationsReport(request, env);
+      }
+      if ((request.method === 'GET' || request.method === 'POST') && url.pathname === '/api/ops/weekly-input') {
+        return weeklyOperations(request, env);
       }
     }
 


### PR DESCRIPTION
- add a private manual workflow for weekly X totals and the 20h/20h time split
- store weekly aggregates in D1 without post content or follower records
- include the latest weekly X and time totals in operating reports