### PR TITLE
Add engagement trends and private Clarity reviews

### DIFF
--- a/.github/workflows/record-clarity-review.yml
+++ b/.github/workflows/record-clarity-review.yml
@@ -1,0 +1,77 @@
+name: Record Clarity Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      week_ending:
+        description: Week ending date (YYYY-MM-DD)
+        required: true
+        type: string
+      page_path:
+        description: Page path reviewed, for example /post/example.html or sitewide
+        required: true
+        default: sitewide
+        type: string
+      recordings_reviewed:
+        description: Number of recordings reviewed
+        required: true
+        default: 10
+        type: number
+      heatmap_finding:
+        description: One concise heatmap finding, without visitor identifiers
+        required: true
+        type: string
+      recording_finding:
+        description: One concise recording finding, without visitor identifiers
+        required: true
+        type: string
+      action_decision:
+        description: Concrete content or page change to test next
+        required: true
+        type: string
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    if: github.repository == 'neverasecond/granthuang999.github.io'
+    env:
+      OPS_ENDPOINT: https://www.790427.xyz/api/ops/clarity-review
+      NEWSLETTER_SEND_TOKEN: ${{ secrets.NEWSLETTER_SEND_TOKEN }}
+      WEEK_ENDING: ${{ inputs.week_ending }}
+      PAGE_PATH: ${{ inputs.page_path }}
+      RECORDINGS_REVIEWED: ${{ inputs.recordings_reviewed }}
+      HEATMAP_FINDING: ${{ inputs.heatmap_finding }}
+      RECORDING_FINDING: ${{ inputs.recording_finding }}
+      ACTION_DECISION: ${{ inputs.action_decision }}
+    steps:
+      - name: Record private Clarity review
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, urllib.request
+
+          payload = {
+              "weekEnding": os.environ["WEEK_ENDING"],
+              "pagePath": os.environ["PAGE_PATH"],
+              "recordingsReviewed": int(os.environ["RECORDINGS_REVIEWED"]),
+              "heatmapFinding": os.environ["HEATMAP_FINDING"],
+              "recordingFinding": os.environ["RECORDING_FINDING"],
+              "actionDecision": os.environ["ACTION_DECISION"],
+          }
+          request = urllib.request.Request(
+              os.environ["OPS_ENDPOINT"],
+              data=json.dumps(payload, ensure_ascii=False).encode(),
+              headers={
+                  "Authorization": f"Bearer {os.environ['NEWSLETTER_SEND_TOKEN']}",
+                  "Content-Type": "application/json; charset=utf-8",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              result = json.load(response)
+          print(json.dumps({
+              "stored": bool(result.get("stored")),
+              "weekEnding": result.get("weekEnding"),
+              "pagePath": result.get("pagePath"),
+          }, ensure_ascii=False))
+          PY

--- a/operations/collect_metrics.py
+++ b/operations/collect_metrics.py
@@ -35,6 +35,22 @@ OPS_ENDPOINT = os.environ.get(
     "OPS_ENDPOINT", f"{SITE_URL}/api/ops"
 ).rstrip("/")
 USER_AGENT = "DailyOperationsMetrics/1.0 (+https://www.790427.xyz/)"
+ENGAGEMENT_EVENTS = (
+    "scroll_50",
+    "scroll_90",
+    "article_share",
+    "related_article_click",
+    "outbound_x_click",
+    "newsletter_submit",
+    "newsletter_confirm",
+)
+ARTICLE_EVENTS = (
+    "scroll_50",
+    "scroll_90",
+    "article_share",
+    "related_article_click",
+    "outbound_x_click",
+)
 
 
 @dataclass
@@ -235,6 +251,189 @@ def collect_ga4(token: str, metric_date: dt.date) -> list[Metric]:
     return metrics
 
 
+def rate(numerator: float, denominator: float) -> float:
+    return round((numerator / denominator) * 100, 4) if denominator > 0 else 0.0
+
+
+def change_rate(current: float, baseline: float) -> float:
+    return round(((current - baseline) / baseline) * 100, 4) if baseline > 0 else 0.0
+
+
+def collect_ga4_window(token: str, metric_date: dt.date, days: int) -> list[Metric]:
+    end_date = metric_date
+    start_date = metric_date - dt.timedelta(days=days - 1)
+    date_range = {
+        "startDate": start_date.isoformat(),
+        "endDate": end_date.isoformat(),
+    }
+    metadata = {"startDate": start_date.isoformat(), "endDate": end_date.isoformat()}
+    summary_source = f"ga4_{days}d"
+    engagement_source = f"ga4_engagement_{days}d"
+    metrics: list[Metric] = []
+
+    summary = ga4_report(
+        token,
+        {
+            "dateRanges": [date_range],
+            "metrics": [
+                {"name": "activeUsers"},
+                {"name": "sessions"},
+                {"name": "engagedSessions"},
+                {"name": "screenPageViews"},
+                {"name": "averageSessionDuration"},
+                {"name": "bounceRate"},
+            ],
+        },
+    )
+    headers = [item["name"] for item in summary.get("metricHeaders", [])]
+    rows = summary.get("rows", [])
+    values = rows[0].get("metricValues", []) if rows else []
+    for name, raw in zip(headers, values):
+        metrics.append(
+            Metric(summary_source, name, float(raw.get("value") or 0), metadata=metadata)
+        )
+
+    event_report = ga4_report(
+        token,
+        {
+            "dateRanges": [date_range],
+            "dimensions": [{"name": "eventName"}],
+            "metrics": [{"name": "eventCount"}],
+            "dimensionFilter": {
+                "filter": {
+                    "fieldName": "eventName",
+                    "inListFilter": {"values": list(ENGAGEMENT_EVENTS)},
+                }
+            },
+            "limit": "50",
+        },
+    )
+    event_counts = {event_name: 0.0 for event_name in ENGAGEMENT_EVENTS}
+    for row in event_report.get("rows", []):
+        event_name = row["dimensionValues"][0].get("value", "")
+        if event_name in event_counts:
+            event_counts[event_name] = float(row["metricValues"][0].get("value") or 0)
+
+    post_pages = ga4_report(
+        token,
+        {
+            "dateRanges": [date_range],
+            "dimensions": [{"name": "pagePath"}],
+            "metrics": [{"name": "screenPageViews"}],
+            "dimensionFilter": {
+                "filter": {
+                    "fieldName": "pagePath",
+                    "stringFilter": {
+                        "matchType": "BEGINS_WITH",
+                        "value": "/post/",
+                        "caseSensitive": False,
+                    },
+                }
+            },
+            "limit": "10000",
+        },
+    )
+    post_page_views = sum(
+        float(row["metricValues"][0].get("value") or 0)
+        for row in post_pages.get("rows", [])
+    )
+    metrics.append(
+        Metric(engagement_source, "postPageViews", post_page_views, metadata=metadata)
+    )
+    for event_name, value in event_counts.items():
+        metrics.append(
+            Metric(engagement_source, event_name, value, metadata=metadata)
+        )
+    metrics.extend(
+        [
+            Metric(
+                engagement_source,
+                "completion50Rate",
+                rate(event_counts["scroll_50"], post_page_views),
+                metadata=metadata,
+            ),
+            Metric(
+                engagement_source,
+                "completion90Rate",
+                rate(event_counts["scroll_90"], post_page_views),
+                metadata=metadata,
+            ),
+            Metric(
+                engagement_source,
+                "shareRate",
+                rate(event_counts["article_share"], post_page_views),
+                metadata=metadata,
+            ),
+            Metric(
+                engagement_source,
+                "relatedClickRate",
+                rate(event_counts["related_article_click"], post_page_views),
+                metadata=metadata,
+            ),
+            Metric(
+                engagement_source,
+                "outboundXRate",
+                rate(event_counts["outbound_x_click"], post_page_views),
+                metadata=metadata,
+            ),
+            Metric(
+                engagement_source,
+                "newsletterConfirmRate",
+                rate(event_counts["newsletter_confirm"], event_counts["newsletter_submit"]),
+                metadata=metadata,
+            ),
+        ]
+    )
+
+    if days == 28:
+        page_events = ga4_report(
+            token,
+            {
+                "dateRanges": [date_range],
+                "dimensions": [{"name": "eventName"}, {"name": "pagePath"}],
+                "metrics": [{"name": "eventCount"}],
+                "dimensionFilter": {
+                    "andGroup": {
+                        "expressions": [
+                            {
+                                "filter": {
+                                    "fieldName": "eventName",
+                                    "inListFilter": {"values": list(ARTICLE_EVENTS)},
+                                }
+                            },
+                            {
+                                "filter": {
+                                    "fieldName": "pagePath",
+                                    "stringFilter": {
+                                        "matchType": "BEGINS_WITH",
+                                        "value": "/post/",
+                                        "caseSensitive": False,
+                                    },
+                                }
+                            },
+                        ]
+                    }
+                },
+                "orderBys": [{"metric": {"metricName": "eventCount"}, "desc": True}],
+                "limit": "100",
+            },
+        )
+        for row in page_events.get("rows", []):
+            event_name = row["dimensionValues"][0].get("value", "")[:120]
+            page_path = row["dimensionValues"][1].get("value", "")[:500]
+            value = float(row["metricValues"][0].get("value") or 0)
+            metrics.append(
+                Metric(
+                    "ga4_event_page_28d",
+                    event_name,
+                    value,
+                    page_path,
+                    metadata,
+                )
+            )
+    return metrics
+
+
 def collect_search_console(token: str, metric_date: dt.date) -> list[Metric]:
     # Search Console is delayed. Use the latest stable 28-day window ending 3 days ago.
     end_date = metric_date - dt.timedelta(days=2)
@@ -354,6 +553,35 @@ def collect_weekly_input() -> list[Metric]:
     return metrics
 
 
+def collect_clarity_review() -> list[Metric]:
+    result = authorized_json("clarity-review")
+    week_ending = str(result.get("weekEnding") or "")
+    reviews = result.get("reviews") if isinstance(result, dict) else []
+    if not week_ending or not isinstance(reviews, list):
+        return []
+    metrics: list[Metric] = []
+    for review in reviews[:20]:
+        if not isinstance(review, dict):
+            continue
+        page_path = str(review.get("pagePath") or "sitewide")[:500]
+        recordings = float(review.get("recordingsReviewed") or 0)
+        metrics.append(
+            Metric(
+                "clarity_review",
+                "recordingsReviewed",
+                recordings,
+                page_path,
+                {
+                    "weekEnding": week_ending,
+                    "heatmapFinding": str(review.get("heatmapFinding") or "")[:1500],
+                    "recordingFinding": str(review.get("recordingFinding") or "")[:1500],
+                    "actionDecision": str(review.get("actionDecision") or "")[:1500],
+                },
+            )
+        )
+    return metrics
+
+
 def check_url(url: str) -> tuple[int, float, str]:
     started = time.monotonic()
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
@@ -410,6 +638,10 @@ def find_metric(metrics: list[Metric], source: str, name: str, dimension: str = 
     return 0.0
 
 
+def find_metrics(metrics: list[Metric], source: str, name: str) -> list[Metric]:
+    return [item for item in metrics if item.source == source and item.metric == name]
+
+
 def fmt_number(value: float, digits: int = 0) -> str:
     return f"{value:,.{digits}f}"
 
@@ -439,6 +671,39 @@ def build_report(
     x_bookmarks = find_metric(metrics, "x_manual", "bookmarks")
     creation_hours = find_metric(metrics, "operations_time", "creationHours")
     interaction_hours = find_metric(metrics, "operations_time", "interactionHours")
+    active_7d = find_metric(metrics, "ga4_7d", "activeUsers")
+    active_28d = find_metric(metrics, "ga4_28d", "activeUsers")
+    views_7d = find_metric(metrics, "ga4_7d", "screenPageViews")
+    views_28d = find_metric(metrics, "ga4_28d", "screenPageViews")
+    views_daily_7d = views_7d / 7
+    views_daily_28d = views_28d / 28
+    views_pace_change = change_rate(views_daily_7d, views_daily_28d)
+    completion_7d = find_metric(metrics, "ga4_engagement_7d", "completion90Rate")
+    completion_28d = find_metric(metrics, "ga4_engagement_28d", "completion90Rate")
+    share_rate_7d = find_metric(metrics, "ga4_engagement_7d", "shareRate")
+    share_rate_28d = find_metric(metrics, "ga4_engagement_28d", "shareRate")
+    related_rate_7d = find_metric(metrics, "ga4_engagement_7d", "relatedClickRate")
+    related_rate_28d = find_metric(metrics, "ga4_engagement_28d", "relatedClickRate")
+    x_outbound_rate_7d = find_metric(metrics, "ga4_engagement_7d", "outboundXRate")
+    x_outbound_rate_28d = find_metric(metrics, "ga4_engagement_28d", "outboundXRate")
+    newsletter_created_7d = find_metric(metrics, "newsletter", "created7d")
+    newsletter_confirmed_7d = find_metric(metrics, "newsletter", "confirmed7d")
+    newsletter_created_28d = find_metric(metrics, "newsletter", "created28d")
+    newsletter_confirmed_28d = find_metric(metrics, "newsletter", "confirmed28d")
+    newsletter_rate_7d = rate(newsletter_confirmed_7d, newsletter_created_7d)
+    newsletter_rate_28d = rate(newsletter_confirmed_28d, newsletter_created_28d)
+    clarity_reviews = find_metrics(metrics, "clarity_review", "recordingsReviewed")
+    clarity_review_count = len(clarity_reviews)
+    clarity_recordings = sum(item.value for item in clarity_reviews)
+    clarity_lines = []
+    for item in clarity_reviews[:5]:
+        metadata = item.metadata or {}
+        clarity_lines.append(
+            f"- {item.dimension}：热图 {metadata.get('heatmapFinding', '')}；"
+            f"录像 {metadata.get('recordingFinding', '')}；"
+            f"动作 {metadata.get('actionDecision', '')}"
+        )
+    clarity_text = "\n".join(clarity_lines) or "- 尚未录入本周人工复盘"
 
     report_titles = {
         "daily": "每日运营基线",
@@ -457,6 +722,15 @@ def build_report(
 - 页面浏览：{fmt_number(views)}
 - 回访活跃用户：{fmt_number(returning)}
 
+网站趋势与内容质量
+- 7日 / 28日活跃用户：{fmt_number(active_7d)} / {fmt_number(active_28d)}
+- 7日 / 28日页面浏览：{fmt_number(views_7d)} / {fmt_number(views_28d)}
+- 7日 / 28日日均页面浏览：{fmt_number(views_daily_7d, 1)} / {fmt_number(views_daily_28d, 1)}（近7日节奏 {views_pace_change:+.2f}%）
+- 90%阅读完成率：{fmt_number(completion_7d, 2)}% / {fmt_number(completion_28d, 2)}%
+- 分享点击率：{fmt_number(share_rate_7d, 2)}% / {fmt_number(share_rate_28d, 2)}%
+- 相关阅读点击率：{fmt_number(related_rate_7d, 2)}% / {fmt_number(related_rate_28d, 2)}%
+- 网站到X点击率：{fmt_number(x_outbound_rate_7d, 2)}% / {fmt_number(x_outbound_rate_28d, 2)}%
+
 Google 搜索（稳定的最近28天窗口）
 - 点击：{fmt_number(clicks)}
 - 展示：{fmt_number(impressions)}
@@ -468,6 +742,13 @@ Google 搜索（稳定的最近28天窗口）
 - 昨日新增：{fmt_number(new_subscribers)}
 - 昨日确认：{fmt_number(confirmed)}
 - 昨日退订：{fmt_number(unsubscribed)}
+- 7日确认转化：{fmt_number(newsletter_confirmed_7d)} / {fmt_number(newsletter_created_7d)}（{fmt_number(newsletter_rate_7d, 2)}%）
+- 28日确认转化：{fmt_number(newsletter_confirmed_28d)} / {fmt_number(newsletter_created_28d)}（{fmt_number(newsletter_rate_28d, 2)}%）
+
+Clarity人工复盘（最近一次周度录入）
+- 复盘页面：{fmt_number(clarity_review_count)}
+- 查看录像：{fmt_number(clarity_recordings)}
+{clarity_text}
 
 X（最近一次周度人工录入）
 - 关注者：{fmt_number(x_followers)}
@@ -491,10 +772,15 @@ X（最近一次周度人工录入）
       <p style="color:#57606a">统计日期：{metric_date.isoformat()}</p>
       <h2 style="font-size:17px">网站（昨日）</h2>
       <ul><li>活跃用户：{fmt_number(active)}</li><li>会话：{fmt_number(sessions)}</li><li>页面浏览：{fmt_number(views)}</li><li>回访活跃用户：{fmt_number(returning)}</li></ul>
+      <h2 style="font-size:17px">网站趋势与内容质量</h2>
+      <ul><li>7日 / 28日活跃用户：{fmt_number(active_7d)} / {fmt_number(active_28d)}</li><li>7日 / 28日页面浏览：{fmt_number(views_7d)} / {fmt_number(views_28d)}</li><li>7日 / 28日日均页面浏览：{fmt_number(views_daily_7d, 1)} / {fmt_number(views_daily_28d, 1)}（近7日节奏 {views_pace_change:+.2f}%）</li><li>90%阅读完成率：{fmt_number(completion_7d, 2)}% / {fmt_number(completion_28d, 2)}%</li><li>分享点击率：{fmt_number(share_rate_7d, 2)}% / {fmt_number(share_rate_28d, 2)}%</li><li>相关阅读点击率：{fmt_number(related_rate_7d, 2)}% / {fmt_number(related_rate_28d, 2)}%</li><li>网站到X点击率：{fmt_number(x_outbound_rate_7d, 2)}% / {fmt_number(x_outbound_rate_28d, 2)}%</li></ul>
       <h2 style="font-size:17px">Google 搜索（稳定的最近28天窗口）</h2>
       <ul><li>点击：{fmt_number(clicks)}</li><li>展示：{fmt_number(impressions)}</li><li>CTR：{fmt_number(ctr, 2)}%</li></ul>
       <h2 style="font-size:17px">邮件订阅</h2>
-      <ul><li>有效订阅：{fmt_number(active_subscribers)}</li><li>待确认：{fmt_number(pending_subscribers)}</li><li>昨日新增：{fmt_number(new_subscribers)}</li><li>昨日确认：{fmt_number(confirmed)}</li><li>昨日退订：{fmt_number(unsubscribed)}</li></ul>
+      <ul><li>有效订阅：{fmt_number(active_subscribers)}</li><li>待确认：{fmt_number(pending_subscribers)}</li><li>昨日新增：{fmt_number(new_subscribers)}</li><li>昨日确认：{fmt_number(confirmed)}</li><li>昨日退订：{fmt_number(unsubscribed)}</li><li>7日确认转化：{fmt_number(newsletter_confirmed_7d)} / {fmt_number(newsletter_created_7d)}（{fmt_number(newsletter_rate_7d, 2)}%）</li><li>28日确认转化：{fmt_number(newsletter_confirmed_28d)} / {fmt_number(newsletter_created_28d)}（{fmt_number(newsletter_rate_28d, 2)}%）</li></ul>
+      <h2 style="font-size:17px">Clarity 人工复盘</h2>
+      <ul><li>复盘页面：{fmt_number(clarity_review_count)}</li><li>查看录像：{fmt_number(clarity_recordings)}</li></ul>
+      <div style="font-size:14px;color:#57606a">{html.escape(clarity_text).replace(chr(10), '<br>')}</div>
       <h2 style="font-size:17px">X（最近一次周度人工录入）</h2>
       <ul><li>关注者：{fmt_number(x_followers)}</li><li>发布数：{fmt_number(x_posts)}</li><li>展示：{fmt_number(x_impressions)}</li><li>收藏：{fmt_number(x_bookmarks)}</li></ul>
       <h2 style="font-size:17px">时间投入（最近一周）</h2>
@@ -537,10 +823,13 @@ def main() -> int:
     token = google_access_token(credentials_json)
     collectors = (
         ("ga4", lambda: collect_ga4(token, metric_date)),
+        ("ga4_7d", lambda: collect_ga4_window(token, metric_date, 7)),
+        ("ga4_28d", lambda: collect_ga4_window(token, metric_date, 28)),
         ("search_console", lambda: collect_search_console(token, metric_date)),
         ("clarity", collect_clarity),
         ("newsletter", lambda: collect_newsletter(metric_date)),
         ("weekly_input", collect_weekly_input),
+        ("clarity_review", collect_clarity_review),
     )
     for source, collector in collectors:
         try:

--- a/operations/schema.sql
+++ b/operations/schema.sql
@@ -57,3 +57,17 @@ CREATE TABLE IF NOT EXISTS weekly_operations (
   interaction_hours REAL,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS clarity_reviews (
+  week_ending TEXT NOT NULL,
+  page_path TEXT NOT NULL,
+  recordings_reviewed INTEGER NOT NULL DEFAULT 0,
+  heatmap_finding TEXT NOT NULL,
+  recording_finding TEXT NOT NULL,
+  action_decision TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (week_ending, page_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_clarity_reviews_week
+ON clarity_reviews(week_ending);

--- a/workers/newsletter/README.md
+++ b/workers/newsletter/README.md
@@ -63,3 +63,15 @@ Resend/SES 等服务需要单独验证 `790427.xyz` 或子域名，并配置 SPF
 ```
 
 Worker 会读取 D1 中 `status = active` 的订阅者，并把每个 `post_url + email` 的发送结果写入 `newsletter_sends`，避免重复发送。
+
+## 私有运营数据
+
+运营数据接口统一使用 `NEWSLETTER_SEND_TOKEN` 鉴权，不向公网暴露报表或原始数据：
+
+- `POST /api/ops/weekly-input`：保存 X 与时间投入的每周合计。
+- `GET /api/ops/weekly-input`：返回最近一周的合计。
+- `POST /api/ops/clarity-review`：保存 Clarity 热图与录像的人工复盘摘要。
+- `GET /api/ops/clarity-review`：返回最近一周的复盘摘要。
+- `GET /api/ops/newsletter-metrics`：返回订阅者的单日、7 日和 28 日汇总。
+
+人工录入通过 GitHub Actions 的 `Record Weekly Operations` 和 `Record Clarity Review` 进行。Clarity 只记录页面级结论、查看录像数量和下一步动作；不录入访客标识、IP、录像链接、邮箱、完整对话或截图。

--- a/workers/newsletter/src/index.js
+++ b/workers/newsletter/src/index.js
@@ -214,6 +214,18 @@ async function ensureOperationsSchema(env) {
       )
     `),
     env.OPS_DB.prepare(`
+      CREATE TABLE IF NOT EXISTS clarity_reviews (
+        week_ending TEXT NOT NULL,
+        page_path TEXT NOT NULL,
+        recordings_reviewed INTEGER NOT NULL DEFAULT 0,
+        heatmap_finding TEXT NOT NULL,
+        recording_finding TEXT NOT NULL,
+        action_decision TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (week_ending, page_path)
+      )
+    `),
+    env.OPS_DB.prepare(`
       CREATE INDEX IF NOT EXISTS idx_daily_metrics_source_date
       ON daily_metrics(source, metric_date)
     `),
@@ -224,6 +236,10 @@ async function ensureOperationsSchema(env) {
     env.OPS_DB.prepare(`
       CREATE INDEX IF NOT EXISTS idx_collection_runs_metric_date
       ON collection_runs(metric_date)
+    `),
+    env.OPS_DB.prepare(`
+      CREATE INDEX IF NOT EXISTS idx_clarity_reviews_week
+      ON clarity_reviews(week_ending)
     `),
   ]);
 }
@@ -276,6 +292,10 @@ async function newsletterMetrics(request, env, metricDate) {
     env.DB.prepare("SELECT COUNT(*) AS value FROM subscribers WHERE DATE(unsubscribed_at, '+8 hours') = ?").bind(metricDate),
     env.DB.prepare("SELECT COUNT(*) AS value FROM newsletter_sends WHERE status = 'sent' AND DATE(sent_at, '+8 hours') = ?").bind(metricDate),
     env.DB.prepare("SELECT COUNT(*) AS value FROM newsletter_sends WHERE status = 'failed' AND DATE(created_at, '+8 hours') = ?").bind(metricDate),
+    env.DB.prepare("SELECT COUNT(*) AS value FROM subscribers WHERE DATE(created_at, '+8 hours') BETWEEN DATE(?, '-6 days') AND ?").bind(metricDate, metricDate),
+    env.DB.prepare("SELECT COUNT(*) AS value FROM subscribers WHERE DATE(confirmed_at, '+8 hours') BETWEEN DATE(?, '-6 days') AND ?").bind(metricDate, metricDate),
+    env.DB.prepare("SELECT COUNT(*) AS value FROM subscribers WHERE DATE(created_at, '+8 hours') BETWEEN DATE(?, '-27 days') AND ?").bind(metricDate, metricDate),
+    env.DB.prepare("SELECT COUNT(*) AS value FROM subscribers WHERE DATE(confirmed_at, '+8 hours') BETWEEN DATE(?, '-27 days') AND ?").bind(metricDate, metricDate),
   ];
   const results = await env.DB.batch(statements);
   const names = [
@@ -287,6 +307,10 @@ async function newsletterMetrics(request, env, metricDate) {
     'unsubscribedYesterday',
     'messagesSentYesterday',
     'messagesFailedYesterday',
+    'created7d',
+    'confirmed7d',
+    'created28d',
+    'confirmed28d',
   ];
   const response = {};
   names.forEach((name, index) => {
@@ -443,6 +467,68 @@ async function weeklyOperations(request, env) {
     values.reposts, values.creationHours, values.interactionHours,
   ).run();
   return json(request, { stored: true, weekEnding });
+}
+
+async function clarityReview(request, env) {
+  if (request.method === 'GET') {
+    await ensureOperationsSchema(env);
+    const latest = await env.OPS_DB.prepare(`
+      SELECT MAX(week_ending) AS weekEnding
+      FROM clarity_reviews
+    `).first();
+    const weekEnding = String(latest?.weekEnding || '');
+    if (!weekEnding) return json(request, { weekEnding: '', reviews: [] });
+
+    const result = await env.OPS_DB.prepare(`
+      SELECT week_ending AS weekEnding, page_path AS pagePath,
+             recordings_reviewed AS recordingsReviewed,
+             heatmap_finding AS heatmapFinding,
+             recording_finding AS recordingFinding,
+             action_decision AS actionDecision
+      FROM clarity_reviews
+      WHERE week_ending = ?
+      ORDER BY page_path ASC
+      LIMIT 20
+    `).bind(weekEnding).all();
+    return json(request, { weekEnding, reviews: result.results || [] });
+  }
+
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return json(request, { message: '请求格式不正确。' }, 400);
+  }
+
+  const weekEnding = String(payload.weekEnding || '');
+  const pagePath = String(payload.pagePath || '').trim().slice(0, 500);
+  const recordingsReviewed = Number(payload.recordingsReviewed);
+  const heatmapFinding = String(payload.heatmapFinding || '').trim().slice(0, 1500);
+  const recordingFinding = String(payload.recordingFinding || '').trim().slice(0, 1500);
+  const actionDecision = String(payload.actionDecision || '').trim().slice(0, 1500);
+  if (!validMetricDate(weekEnding) || !pagePath ||
+      !Number.isInteger(recordingsReviewed) || recordingsReviewed < 0 ||
+      !heatmapFinding || !recordingFinding || !actionDecision) {
+    return json(request, { message: 'Clarity 周度复盘字段不完整或不合法。' }, 400);
+  }
+
+  await ensureOperationsSchema(env);
+  await env.OPS_DB.prepare(`
+    INSERT INTO clarity_reviews (
+      week_ending, page_path, recordings_reviewed, heatmap_finding,
+      recording_finding, action_decision, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(week_ending, page_path) DO UPDATE SET
+      recordings_reviewed = excluded.recordings_reviewed,
+      heatmap_finding = excluded.heatmap_finding,
+      recording_finding = excluded.recording_finding,
+      action_decision = excluded.action_decision,
+      updated_at = CURRENT_TIMESTAMP
+  `).bind(
+    weekEnding, pagePath, recordingsReviewed, heatmapFinding,
+    recordingFinding, actionDecision,
+  ).run();
+  return json(request, { stored: true, weekEnding, pagePath });
 }
 
 function postNotificationHtml(env, post, subscriber) {
@@ -774,6 +860,9 @@ export default {
       }
       if ((request.method === 'GET' || request.method === 'POST') && url.pathname === '/api/ops/weekly-input') {
         return weeklyOperations(request, env);
+      }
+      if ((request.method === 'GET' || request.method === 'POST') && url.pathname === '/api/ops/clarity-review') {
+        return clarityReview(request, env);
       }
     }
 


### PR DESCRIPTION
## Summary
- collect 7/28-day GA4 engagement and reading completion trends
- report newsletter confirmation conversion from D1
- add a private, aggregate-only Clarity review workflow and API
- document the private operations endpoints and privacy boundary

## Validation
- Python compile and report smoke test
- Node syntax check
- workflow YAML parsing
- git diff --check