### PR TITLE
Fix article publication triggers

### DIFF
--- a/.github/workflows/Gmeek.yml
+++ b/.github/workflows/Gmeek.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+    # Article images are staged before an Issue is published. They are copied
+    # and deployed by the later label-triggered incremental build.
+    paths-ignore:
+      - "static/images/**"
+      - "docs/**"
+      - "backup/**"
+      - "blogBase.json"
+      - "README.md"
+      - ".github/url-submission-history/**"
   workflow_dispatch:
   schedule:
     - cron: "16 4 * * *"

--- a/.github/workflows/incremental-build.yml
+++ b/.github/workflows/incremental-build.yml
@@ -2,7 +2,9 @@ name: Incremental Build (Issues)
 
 on:
   issues:
-    types: [opened, edited]
+    # New Issues start without labels and are drafts. Publishing begins when
+    # the first label is added; later edits to a published Issue rebuild it.
+    types: [edited, labeled]
 
 jobs:
   build-incremental:
@@ -13,7 +15,8 @@ jobs:
       cancel-in-progress: true
     if: |
       github.actor != 'github-actions[bot]' &&
-      github.repository == 'neverasecond/granthuang999.github.io'
+      github.repository == 'neverasecond/granthuang999.github.io' &&
+      join(github.event.issue.labels.*.name, '') != ''
     permissions:
       contents: write
       issues: read


### PR DESCRIPTION
## Root cause
- Full Build listened to every push on main, including staged article images and generated-file commits.
- Incremental Build listened to Issue creation but not the publishing action of adding a label.
- Unlabeled draft Issues therefore spent runner time while label-based publication required a manual build.

## Changes
- Ignore article-image and generated-output-only pushes in Full Build.
- Stop listening to Issue creation.
- Trigger Incremental Build on labeled and edited events.
- Skip the incremental job whenever the Issue has no labels.

## Expected flow
1. Commit an article image without building.
2. Create an unlabeled Issue draft without building.
3. Add a publishing label to build, deploy, submit URLs, and notify subscribers.
4. Edit a labeled article to rebuild it.

## Validation
- YAML parse for both workflows
- git diff --check
- verified Gmeek runOne synchronizes static assets