### PR TITLE
Align site with Midlife Order pillars

### DIFF
--- a/.github/workflows/deploy-newsletter-worker.yml
+++ b/.github/workflows/deploy-newsletter-worker.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       - "workers/newsletter/**"
-      - "operations/**"
+      - "operations/schema.sql"
       - ".github/workflows/deploy-newsletter-worker.yml"
 
 jobs:

--- a/.github/workflows/incremental-build.yml
+++ b/.github/workflows/incremental-build.yml
@@ -4,7 +4,7 @@ on:
   issues:
     # New Issues start without labels and are drafts. Publishing begins when
     # the first label is added; later edits to a published Issue rebuild it.
-    types: [edited, labeled]
+    types: [opened, edited, labeled, unlabeled, closed, reopened, deleted]
 
 jobs:
   build-incremental:
@@ -16,7 +16,17 @@ jobs:
     if: |
       github.actor != 'github-actions[bot]' &&
       github.repository == 'neverasecond/granthuang999.github.io' &&
-      join(github.event.issue.labels.*.name, '') != ''
+      (github.event.action == 'closed' ||
+       github.event.action == 'deleted' ||
+       github.event.action == 'unlabeled' ||
+       contains(github.event.issue.labels.*.name, 'Draft') ||
+       contains(github.event.issue.labels.*.name, '草稿') ||
+       contains(github.event.issue.labels.*.name, '内心秩序') ||
+       contains(github.event.issue.labels.*.name, '资产护航') ||
+       contains(github.event.issue.labels.*.name, '数字能力') ||
+       contains(github.event.issue.labels.*.name, '人生修行') ||
+       contains(github.event.issue.labels.*.name, '赚钱投资') ||
+       contains(github.event.issue.labels.*.name, '技术辅助'))
     permissions:
       contents: write
       issues: read
@@ -45,8 +55,13 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Generate new html (Cleanup Full Build)
+        if: github.event.action == 'closed' || github.event.action == 'deleted' || github.event.action == 'unlabeled' || contains(github.event.issue.labels.*.name, 'Draft') || contains(github.event.issue.labels.*.name, '草稿')
+        run: |
+          python Gmeek.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }}
+
       - name: Generate new html (Incremental)
-        if: steps.determine_issue.outputs.issue_number != ''
+        if: steps.determine_issue.outputs.issue_number != '' && github.event.action != 'closed' && github.event.action != 'deleted' && github.event.action != 'unlabeled' && !contains(github.event.issue.labels.*.name, 'Draft') && !contains(github.event.issue.labels.*.name, '草稿')
         run: |
           python Gmeek.py ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} --issue_number '${{ steps.determine_issue.outputs.issue_number }}'
 

--- a/Gmeek.py
+++ b/Gmeek.py
@@ -98,9 +98,12 @@ class GMEEK:
     def defaultConfig(self):
         with open('config.json', 'r', encoding='utf-8') as f:
             config = json.load(f)
-        dconfig={"singlePage":[],"hiddenPage":[],"disabledPage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","author":"莫白来","xName":"莫白来","xHandle":"wiselyfreely","xUrl":"https://x.com/wiselyfreely","enableAds":0,"subscribeApiUrl":"","turnstileSiteKey":"","contentCategorySlugs":{"人生修行":"xiu-xing","赚钱投资":"tou-zi","技术辅助":"ai-jiao-xue"}}
+        dconfig={"singlePage":[],"hiddenPage":[],"disabledPage":[],"startSite":"","filingNum":"","onePageListNum":15,"commentLabelColor":"#006b75","yearColorList":["#bc4c00", "#0969da", "#1f883d", "#A333D0"],"i18n":"CN","themeMode":"manual","dayTheme":"light","nightTheme":"dark","urlMode":"pinyin","script":"","style":"","head":"","indexScript":"","indexStyle":"","bottomText":"","showPostSource":1,"iconList":{},"UTC":8,"rssSplit":"sentence","exlink":{},"needComment":1,"allHead":"","author":"莫白来","linkedinUrl":"","youtubeUrl":"","enableAds":0,"subscribeApiUrl":"","turnstileSiteKey":"","contentCategorySlugs":{"内心秩序":"nei-xin-zhi-xu","资产护航":"zi-chan-hu-hang","数字能力":"shu-zi-neng-li"},"contentCategoryAliases":{"人生修行":"内心秩序","赚钱投资":"资产护航","技术辅助":"数字能力"},"legacyCategoryRedirects":{"xiu-xing.html":"nei-xin-zhi-xu.html","tou-zi.html":"zi-chan-hu-hang.html","ai-jiao-xue.html":"shu-zi-neng-li.html"}}
 
         self.blogBase={**dconfig,**config}
+        for legacy_label, canonical_label in self.blogBase.get("contentCategoryAliases", {}).items():
+            if legacy_label in self.labelColorDict and canonical_label not in self.labelColorDict:
+                self.labelColorDict[canonical_label] = self.labelColorDict[legacy_label]
         self.blogBase["postListJson"]={}
         self.blogBase["singeListJson"]={}
         self.blogBase["labelColorDict"]=self.labelColorDict
@@ -125,11 +128,22 @@ class GMEEK:
 
     def getLabelSlug(self, label):
         """Keep primary category URLs stable while auxiliary tags use pinyin."""
-        return self.blogBase.get("contentCategorySlugs", {}).get(label, Pinyin().get_pinyin(label))
+        canonical_label = self.blogBase.get("contentCategoryAliases", {}).get(label, label)
+        return self.blogBase.get("contentCategorySlugs", {}).get(canonical_label, Pinyin().get_pinyin(label))
+
+    def normalizeLabels(self, labels):
+        """Map legacy editorial labels to their current public names."""
+        aliases = self.blogBase.get("contentCategoryAliases", {})
+        normalized = []
+        for label in labels:
+            canonical_label = aliases.get(label, label)
+            if canonical_label not in normalized:
+                normalized.append(canonical_label)
+        return normalized
 
     def getContentCategory(self, labels):
         """Return the single editorial category independent of GitHub label order."""
-        label_names = [label.name if hasattr(label, "name") else label for label in labels]
+        label_names = self.normalizeLabels([label.name if hasattr(label, "name") else label for label in labels])
         for category in self.blogBase.get("contentCategorySlugs", {}):
             if category in label_names:
                 return category
@@ -144,7 +158,7 @@ class GMEEK:
         categories = set(self.blogBase.get("contentCategorySlugs", {}))
         invalid_posts = []
         for issue_key, post in self.blogBase["postListJson"].items():
-            matches = sorted(categories.intersection(post.get("labels", [])))
+            matches = sorted(categories.intersection(self.normalizeLabels(post.get("labels", []))))
             if len(matches) != 1:
                 invalid_posts.append(f"{issue_key}: {post['postTitle']} ({', '.join(matches) or '无正式栏目'})")
         if invalid_posts:
@@ -334,6 +348,9 @@ class GMEEK:
 
         page_label = self.getSinglePageLabel(issue_labels)
         is_single_page = bool(page_label)
+        if not is_single_page and ({"Draft", "草稿"}.intersection(issue_labels) or not self.getContentCategory(issue_labels)):
+            print(f"Skipping issue #{issue.number} because it is an unpublished draft without a content category.")
+            return
         listJsonName = 'singeListJson' if is_single_page else 'postListJson'
 
         fileName = self.createFileName(issue, postConfig, page_label=page_label)
@@ -348,7 +365,7 @@ class GMEEK:
 
         post_data = {
             "htmlDir": html_dir,
-            "labels": issue_labels,
+            "labels": self.normalizeLabels(issue_labels),
             "contentCategory": self.getContentCategory(issue_labels),
             "postTitle": issue.title,
             "postUrl": f"{self.blogBase['homeUrl']}/{urllib.parse.quote(relative_url)}",
@@ -591,6 +608,20 @@ class GMEEK:
         }
         self.renderHtml('subscribe.html', context, f"{self.root_dir}subscribe.html")
 
+    def createLegacyCategoryRedirects(self):
+        print("====== create legacy category redirects ======")
+        for legacy_file, target_file in self.blogBase.get("legacyCategoryRedirects", {}).items():
+            target_url = f"{self.blogBase['homeUrl']}/{target_file}"
+            redirect_html = f'''<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8">
+<meta name="robots" content="noindex,follow">
+<link rel="canonical" href="{target_url}">
+<meta http-equiv="refresh" content="0;url={target_url}">
+<title>页面已迁移</title></head>
+<body><p>页面已迁移至 <a href="{target_url}">{target_url}</a>。</p></body></html>'''
+            with open(os.path.join(self.root_dir, legacy_file), 'w', encoding='UTF-8') as f:
+                f.write(redirect_html)
+
     def createStaticLandingPages(self):
         print("====== create static landing pages ======")
         pages = [
@@ -639,6 +670,7 @@ class GMEEK:
         self.createPlistHtml()
         self.createTagCloudPage()
         self.createTagPages()
+        self.createLegacyCategoryRedirects()
         self.createSubscribePage()
         self.createStaticLandingPages()
         self.createNotFoundPage()
@@ -672,6 +704,7 @@ class GMEEK:
             self.createPlistHtml()
             self.createTagCloudPage()
             self.createTagPages()
+            self.createLegacyCategoryRedirects()
             self.createSubscribePage()
             self.createStaticLandingPages()
             self.createNotFoundPage()

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "title":"人到中年",
-    "subTitle":"可以对别人失望，但自己不能绝望。写写人生修行、赚钱投资、技术辅助。世界不会变得更好，但你可以。愿你莫白来，与君共勉！",
+    "subTitle":"帮助全球华语中年人建立内在秩序、资产秩序和数字能力，并逐步为英语读者提供同样的方法与工具。",
     "avatarUrl":"/images/site-logo.svg",
     "GMEEK_VERSION":"last",
     "displayTitle":"人到中年",
@@ -11,13 +11,22 @@
 "headerBackgroundUrl": "/images/header-bg.jpg",
 "email":"service@790427.xyz",
 "author":"莫白来",
-"xName":"莫白来",
-"xHandle":"wiselyfreely",
-"xUrl":"https://x.com/wiselyfreely",
+"linkedinUrl":"",
+"youtubeUrl":"",
 "contentCategorySlugs": {
-    "人生修行": "xiu-xing",
-    "赚钱投资": "tou-zi",
-    "技术辅助": "ai-jiao-xue"
+    "内心秩序": "nei-xin-zhi-xu",
+    "资产护航": "zi-chan-hu-hang",
+    "数字能力": "shu-zi-neng-li"
+},
+"contentCategoryAliases": {
+    "人生修行": "内心秩序",
+    "赚钱投资": "资产护航",
+    "技术辅助": "数字能力"
+},
+"legacyCategoryRedirects": {
+    "xiu-xing.html": "nei-xin-zhi-xu.html",
+    "tou-zi.html": "zi-chan-hu-hang.html",
+    "ai-jiao-xue.html": "shu-zi-neng-li.html"
 },
 "enableAds":0,
 "subscribeApiUrl":"https://www.790427.xyz/api/subscribe",
@@ -43,7 +52,7 @@
 "indexScript":"",
 "showPostSource":0,
 "rssSplit":"sentence",
-"bottomText":"文章皆为原创，转载文章请注明出处。人到中年，记录人生修行、赚钱投资与技术辅助。愿你莫白来。",
+"bottomText":"文章皆为原创，转载文章请注明出处。人到中年，记录内心秩序、资产护航与数字能力。愿你莫白来。",
 "primerCSS":"<link href='https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/Primer/21.0.7/primer.css' rel='stylesheet' />",
 "needComment":0
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -2,7 +2,7 @@
 
 {% block head %}
 <meta name="robots" content="noindex,follow">
-<meta name="description" content="页面不存在，返回人到中年继续阅读人生修行、赚钱投资与技术辅助内容。">
+<meta name="description" content="页面不存在，返回人到中年继续阅读内心秩序、资产护航与数字能力内容。">
 <meta property="og:title" content="页面不存在 - {{ blogBase['title'] }}">
 <meta property="og:description" content="这页暂时没有内容，回到人到中年继续阅读。">
 <meta property="og:type" content="website">
@@ -43,9 +43,9 @@
     <nav class="not-found-actions" aria-label="404 导航">
         <a href="{{ blogBase['homeUrl'] }}/">首页</a>
         <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
-        <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">人生修行</a>
-        <a href="{{ blogBase['homeUrl'] }}/tou-zi.html">赚钱投资</a>
-        <a href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">技术辅助</a>
+        <a href="{{ blogBase['homeUrl'] }}/nei-xin-zhi-xu.html">内心秩序</a>
+        <a href="{{ blogBase['homeUrl'] }}/zi-chan-hu-hang.html">资产护航</a>
+        <a href="{{ blogBase['homeUrl'] }}/shu-zi-neng-li.html">数字能力</a>
         <a href="{{ blogBase['homeUrl'] }}/tag.html">搜索</a>
     </nav>
 </main>

--- a/templates/about.html
+++ b/templates/about.html
@@ -7,8 +7,6 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ blogBase['homeUrl'] }}/about.html">
 <meta property="og:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
 <title>关于本站 - {{ blogBase['title'] }}</title>
 <script type="application/ld+json">
 {
@@ -26,10 +24,10 @@
     "author": {
         "@type": "Person",
         "name": {{ blogBase.author|tojson }},
-        "alternateName": {{ blogBase.xName|tojson }},
+        "alternateName": "Midlife Order",
         "url": {{ blogBase.homeUrl|tojson }},
         "email": {{ ("mailto:" ~ blogBase.email)|tojson }},
-        "sameAs": [{{ blogBase.xUrl|tojson }}]
+        "sameAs": []
     }
 }
 </script>
@@ -66,7 +64,7 @@
 {% block content %}
 <main class="content-page">
     <p class="lead">人到中年，是莫白来写给自己，也写给还想重新开始的人的个人网站。</p>
-    <p>这里不追逐热闹，也不制造焦虑。它记录三件事：人生修行、赚钱投资，以及面向中老年人的技术辅助。</p>
+    <p>这里不追逐热闹，也不制造焦虑。它围绕三件事持续写作：内心秩序、资产护航与数字能力。</p>
 
     <h2>这个网站写什么</h2>
     <ul>
@@ -83,12 +81,12 @@
     </ul>
 
     <h2>联系与订阅</h2>
-    <p>你可以写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，也可以在 X 上关注 <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">{{ blogBase['xName'] }}</a>。</p>
+    <p>你可以写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，也可以订阅网站邮件收到新文章与系列整理。</p>
     <p class="notice">投资相关内容仅为个人研究、记录与复盘，不构成任何投资建议。请根据自己的风险承受能力独立判断。</p>
     <div class="page-links">
         <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
         <a href="{{ blogBase['homeUrl'] }}/subscribe.html">邮件订阅</a>
-        <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">关注 X</a>
+        {% if blogBase['linkedinUrl'] %}<a href="{{ blogBase['linkedinUrl'] }}" target="_blank" rel="noopener">关注 LinkedIn</a>{% endif %}
     </div>
 </main>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,10 +53,7 @@
     "publisher": {
         "@type": "Person",
         "name": {{ blogBase.author|tojson }},
-        "url": {{ blogBase.xUrl|tojson }},
-        "sameAs": [
-            {{ blogBase.xUrl|tojson }}
-        ]
+        "url": {{ blogBase.homeUrl|tojson }}
     },
     "potentialAction": {
         "@type": "SearchAction",
@@ -73,12 +70,10 @@
     "@context": "https://schema.org",
     "@type": "Person",
     "name": {{ blogBase.author|tojson }},
-    "alternateName": {{ blogBase.xName|tojson }},
+    "alternateName": "Midlife Order",
     "url": {{ blogBase.homeUrl|tojson }},
     "email": {{ ("mailto:" ~ blogBase.email)|tojson }},
-    "sameAs": [
-        {{ blogBase.xUrl|tojson }}
-    ]
+    "sameAs": []
 }
 </script>
 </head>
@@ -286,9 +281,9 @@ body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;
         <nav class="header-nav-menu">
             <a href="{{ blogBase['homeUrl'] }}/">首页</a>
             <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
-            <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">人生修行</a>
-            <a href="{{ blogBase['homeUrl'] }}/tou-zi.html">赚钱投资</a>
-            <a href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">技术辅助</a>
+            <a href="{{ blogBase['homeUrl'] }}/nei-xin-zhi-xu.html">内心秩序</a>
+            <a href="{{ blogBase['homeUrl'] }}/zi-chan-hu-hang.html">资产护航</a>
+            <a href="{{ blogBase['homeUrl'] }}/shu-zi-neng-li.html">数字能力</a>
             <a href="{{ blogBase['homeUrl'] }}/subscribe.html">订阅</a>
             <a href="{{ blogBase['homeUrl'] }}/about.html">关于</a>
             <a href="{{ blogBase['homeUrl'] }}/tag.html">搜索</a>
@@ -363,17 +358,6 @@ console.log("\n %c 人到中年 " + {{ blogBase['GMEEK_VERSION']|tojson }} + " h
             });
         }
 
-        try {
-            const destination = new URL(link.href, window.location.href);
-            if (destination.hostname === 'x.com' || destination.hostname === 'www.x.com' || destination.hostname === 'twitter.com') {
-                window.trackSiteEvent('outbound_x_click', {
-                    link_url: destination.href,
-                    link_text: (link.textContent || '').trim().slice(0, 120)
-                });
-            }
-        } catch (_) {
-            // Ignore non-HTTP links such as mailto and javascript URLs.
-        }
     });
 
     const postBody = document.getElementById('postBody');

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -10,11 +10,7 @@
     {%- if blogBase['filingNum']!='' -%}
     <span id="filingNum"><a href="https://beian.miit.gov.cn/" target="_blank">{{ blogBase['filingNum'] }}</a> • </span>
     {%- endif %}
-    <span id="runday"></span><span>本站由
-        <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener" title="X: {{ blogBase['xName'] }}" style="display:inline-flex;vertical-align:-3px;margin:0 4px;text-decoration:none;">
-            <img src="{{ blogBase['homeUrl'] }}/images/logo.png" alt="X: {{ blogBase['xName'] }}" width="18" height="18" style="border-radius:50%;">
-        </a>
-        <a href="mailto:{{ blogBase['email'] }}" target="_blank">{{ blogBase['xName'] }}</a> 建立&维护</span>
+    <span id="runday"></span><span>本站由 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['author'] }}</a> 建立&维护</span>
 </div>
 
 <script>

--- a/templates/plist.html
+++ b/templates/plist.html
@@ -6,11 +6,6 @@
 <meta property="og:type" content="blog">
 <meta property="og:url" content="{{ blogBase['homeUrl'] }}">
 <meta property="og:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ blogBase['title'] }}">
-<meta name="twitter:description" content="{{ blogBase['subTitle'] }}">
-<meta name="twitter:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
 <title>{{ blogBase['title'] }}</title>
 <script type="application/ld+json">
 {
@@ -68,7 +63,7 @@
     <div class="home-actions">
         <a href="{{ blogBase['homeUrl'] }}/start.html">从这里开始</a>
         <a href="{{ blogBase['homeUrl'] }}/subscribe.html">邮件订阅</a>
-        <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">关注 {{ blogBase['xName'] }}</a>
+        {% if blogBase['linkedinUrl'] %}<a href="{{ blogBase['linkedinUrl'] }}" target="_blank" rel="noopener">关注 LinkedIn</a>{% endif %}
         <a href="{{ blogBase['homeUrl'] }}/tag.html" id="buttonSearch" class="home-action-icon" title="{{ i18n['Search'] }}" aria-label="{{ i18n['Search'] }}">
             <svg class="octicon" width="16" height="16"><path id="pathSearch" fill-rule="evenodd"></path></svg>
         </a>
@@ -92,17 +87,17 @@
         </button>
     </div>
     <div class="home-tracks">
-        <a class="home-track" href="{{ blogBase['homeUrl'] }}/xiu-xing.html">
-            <strong>人生修行</strong>
-            <span>读书体悟、人生下半场、关系、健康、心态和自我修正。</span>
+        <a class="home-track" href="{{ blogBase['homeUrl'] }}/nei-xin-zhi-xu.html">
+            <strong>内心秩序</strong>
+            <span>经典阅读、关系、健康、心态与自我修正，让现实生活里多一点清醒。</span>
         </a>
-        <a class="home-track" href="{{ blogBase['homeUrl'] }}/tou-zi.html">
-            <strong>赚钱投资</strong>
-            <span>大类资产趋势、ETF 配置、实操记录、风险控制和阶段复盘。</span>
+        <a class="home-track" href="{{ blogBase['homeUrl'] }}/zi-chan-hu-hang.html">
+            <strong>资产护航</strong>
+            <span>现金流、大类资产、ETF 配置、风险边界与阶段复盘。</span>
         </a>
-        <a class="home-track" href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">
-            <strong>技术辅助</strong>
-            <span>不追新工具，不做新闻搬运。只记录 iPhone、AI 与自动化怎样解决真实生活问题。</span>
+        <a class="home-track" href="{{ blogBase['homeUrl'] }}/shu-zi-neng-li.html">
+            <strong>数字能力</strong>
+            <span>用 iPhone、AI 与自动化解决真实问题，同时保留隐私、安全和控制权。</span>
         </a>
     </div>
 </section>

--- a/templates/post.html
+++ b/templates/post.html
@@ -2,11 +2,11 @@
 
 {% block head %}
 <meta name="description" content="{{ blogBase['description'] }}">
-{% if blogBase['contentCategory'] == '赚钱投资' %}
+{% if blogBase['contentCategory'] == '资产护航' %}
 <meta name="content-line" content="investment">
-{% elif blogBase['contentCategory'] == '技术辅助' %}
+{% elif blogBase['contentCategory'] == '数字能力' %}
 <meta name="content-line" content="iphone_ai">
-{% elif blogBase['contentCategory'] == '人生修行' %}
+{% elif blogBase['contentCategory'] == '内心秩序' %}
 <meta name="content-line" content="reading_life">
 {% else %}
 <meta name="content-line" content="other">
@@ -17,11 +17,6 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="{{ blogBase['postUrl'] }}">
 <meta property="og:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ blogBase['postTitle'] }}">
-<meta name="twitter:description" content="{{ blogBase['description'] }}">
-<meta name="twitter:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
 <title>{{ blogBase['postTitle'] }}</title>
 {% if blogBase['highlight']==1 %}<link href="//unpkg.com/@wooorm/starry-night@2.1.1/style/both.css" rel="stylesheet" />{% endif %}
 {{ blogBase['head']|safe }}
@@ -47,9 +42,7 @@
         "@type": "Person",
         "name": {{ blogBase.author|tojson }},
         "url": {{ blogBase.homeUrl|tojson }},
-        "sameAs": [
-            {{ blogBase.xUrl|tojson }}
-        ]
+        "sameAs": []
     },
     "publisher": {
         "@type": "Organization",
@@ -150,12 +143,7 @@
     font-size: small;
     white-space: nowrap; 
 }
-.share-button.x { background-color: #1DA1F2; }
-.share-button.facebook { background-color: #1877F2; }
 .share-button.linkedin { background-color: #0A66C2; }
-.share-button.weibo { background-color: #e6162d; }
-.share-button.telegram { background-color: #26A5E4; }
-.share-button.wechat { background-color: #07C160; }
 .post-nav {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -248,12 +236,8 @@
 <div class="post-footer">
     <div class="bottom-text-inline">{{ blogBase['bottomText'] }}</div>
     <div class="share-buttons-inline">
-        <a id="share-x" class="share-button x" href="#" target="_blank" title="分享到 X">X</a>
-        <a id="share-facebook" class="share-button facebook" href="#" target="_blank" title="分享到 Facebook">Facebook</a>
         <a id="share-linkedin" class="share-button linkedin" href="#" target="_blank" title="分享到 LinkedIn">LinkedIn</a>
-        <a id="share-weibo" class="share-button weibo" href="#" target="_blank" title="分享到微博">微博</a>
-        <a id="share-telegram" class="share-button telegram" href="#" target="_blank" title="分享到 Telegram">Telegram</a>
-        <a id="share-wechat" class="share-button wechat" href="#" onclick="shareToWechat(); return false;" title="分享到微信朋友圈">微信</a>
+        <a id="share-email" class="share-button" href="#" title="通过邮件分享">邮件</a>
     </div>
 </div>
 
@@ -283,169 +267,6 @@
 
 {% block script %}
 <script>
-// 微信分享功能
-function shareToWechat() {
-    const postUrl = window.location.href;
-    const postTitle = document.title;
-
-    // 检测是否在微信浏览器中
-    function isWechat() {
-        const ua = navigator.userAgent.toLowerCase();
-        return ua.indexOf('micromessenger') !== -1;
-    }
-
-    // 检测是否在移动设备上
-    function isMobile() {
-        return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-    }
-
-    if (isWechat()) {
-        // 在微信浏览器中，显示分享提示
-        showWechatShareTip();
-    } else if (isMobile()) {
-        // 移动设备上，尝试调用微信分享或显示引导
-        if (navigator.share) {
-            // 使用 Web Share API
-            navigator.share({
-                title: postTitle,
-                url: postUrl
-            }).catch(console.error);
-        } else {
-            showWechatShareTip();
-        }
-    } else {
-        // 桌面设备，显示二维码或复制链接
-        showWechatShareModal();
-    }
-}
-
-function showWechatShareTip() {
-    // 创建分享提示弹窗
-    const modal = document.createElement('div');
-    modal.style.cssText = `
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0,0,0,0.8);
-        z-index: 10000;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    `;
-
-    const content = document.createElement('div');
-    content.style.cssText = `
-        background: white;
-        padding: 30px;
-        border-radius: 10px;
-        text-align: center;
-        max-width: 300px;
-        color: #333;
-    `;
-
-    content.innerHTML = `
-        <h3 style="margin: 0 0 20px 0; color: #07C160;">微信分享</h3>
-        <p style="margin: 0 0 20px 0; line-height: 1.5;">
-            点击右上角的"..."按钮<br>
-            选择"分享到朋友圈"
-        </p>
-        <button onclick="this.closest('div[style*=\"position: fixed\"]').remove()" 
-                style="background: #07C160; color: white; border: none; padding: 10px 20px; border-radius: 5px; cursor: pointer;">
-            知道了
-        </button>
-    `;
-
-    modal.appendChild(content);
-    document.body.appendChild(modal);
-
-    // 点击背景关闭弹窗
-    modal.addEventListener('click', function(e) {
-        if (e.target === modal) {
-            modal.remove();
-        }
-    });
-}
-
-function showWechatShareModal() {
-    const postUrl = window.location.href;
-    const postTitle = document.title;
-
-    // 创建二维码分享弹窗
-    const modal = document.createElement('div');
-    modal.style.cssText = `
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0,0,0,0.8);
-        z-index: 10000;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    `;
-
-    const content = document.createElement('div');
-    content.style.cssText = `
-        background: white;
-        padding: 30px;
-        border-radius: 10px;
-        text-align: center;
-        max-width: 400px;
-        color: #333;
-    `;
-
-    // 生成二维码URL（使用免费的二维码生成服务）
-    const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(postUrl)}`;
-
-    content.innerHTML = `
-        <h3 style="margin: 0 0 20px 0; color: #07C160;">分享到微信朋友圈</h3>
-        <div style="margin: 20px 0;">
-            <img src="${qrUrl}" alt="二维码" style="width: 200px; height: 200px; border: 1px solid #eee;">
-        </div>
-        <p style="margin: 10px 0; font-size: 14px; color: #666;">
-            用微信扫描二维码分享
-        </p>
-        <div style="margin: 20px 0; padding: 10px; background: #f5f5f5; border-radius: 5px; word-break: break-all; font-size: 12px;">
-            ${postUrl}
-        </div>
-        <button onclick="copyToClipboard('${postUrl.replace(/'/g, "\'")}'); this.innerText='已复制!'; setTimeout(() => this.innerText='复制链接', 2000);" 
-                style="background: #07C160; color: white; border: none; padding: 8px 16px; border-radius: 5px; cursor: pointer; margin-right: 10px;">
-            复制链接
-        </button>
-        <button onclick="this.closest('div[style*=\"position: fixed\"]').remove()" 
-                style="background: #ccc; color: white; border: none; padding: 8px 16px; border-radius: 5px; cursor: pointer;">
-            关闭
-        </button>
-    `;
-
-    modal.appendChild(content);
-    document.body.appendChild(modal);
-
-    // 点击背景关闭弹窗
-    modal.addEventListener('click', function(e) {
-        if (e.target === modal) {
-            modal.remove();
-        }
-    });
-}
-
-function copyToClipboard(text) {
-    if (navigator.clipboard) {
-        navigator.clipboard.writeText(text);
-    } else {
-        // 兼容老版本浏览器
-        const tempTextArea = document.createElement('textarea');
-        tempTextArea.value = text;
-        document.body.appendChild(tempTextArea);
-        tempTextArea.select();
-        document.execCommand('copy');
-        document.body.removeChild(tempTextArea);
-    }
-}
-
 document.addEventListener('DOMContentLoaded', function() {
     const quoteText = "{{ blogBase['quote'] }}";
     const dailySentenceRaw = `{{ blogBase['daily_sentence']|tojson }}`; 
@@ -485,16 +306,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const postTitle = document.title;
     const encodedUrl = encodeURIComponent(postUrl);
     const encodedTitle = encodeURIComponent(postTitle);
-    const shareX = document.getElementById('share-x');
-    const shareFacebook = document.getElementById('share-facebook');
     const shareLinkedin = document.getElementById('share-linkedin');
-    const shareWeibo = document.getElementById('share-weibo');
-    const shareTelegram = document.getElementById('share-telegram');
-    if (shareX) { shareX.href = `https://x.com/intent/post?url=${encodedUrl}&text=${encodedTitle}`; }
-    if (shareFacebook) { shareFacebook.href = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`; }
+    const shareEmail = document.getElementById('share-email');
     if (shareLinkedin) { shareLinkedin.href = `https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}&summary=${encodedTitle}&source={{ blogBase['homeUrl'] }}`; }
-    if (shareWeibo) { shareWeibo.href = `http://service.weibo.com/share/share.php?url=${encodedUrl}&title=${encodedTitle}&pic={{ blogBase['ogImage'] }}`; }
-    if (shareTelegram) { shareTelegram.href = `https://t.me/share/url?url=${encodedUrl}&text=${encodedTitle}`; }
+    if (shareEmail) { shareEmail.href = `mailto:?subject=${encodedTitle}&body=${encodedUrl}`; }
 });
 
 document.getElementById("pathHome").setAttribute("d",IconList["home"]);

--- a/templates/start.html
+++ b/templates/start.html
@@ -1,21 +1,19 @@
 {% extends 'base.html' %}
 
 {% block head %}
-<meta name="description" content="从这里开始阅读人到中年：人生修行、赚钱投资、技术辅助三条原创主线。">
+<meta name="description" content="从这里开始阅读人到中年：内心秩序、资产护航、数字能力三条原创主线。">
 <meta property="og:title" content="从这里开始 - {{ blogBase['title'] }}">
-<meta property="og:description" content="按人生修行、赚钱投资、技术辅助三条原创主线进入人到中年。">
+<meta property="og:description" content="按内心秩序、资产护航、数字能力三条原创主线进入人到中年。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ blogBase['homeUrl'] }}/start.html">
 <meta property="og:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
 <title>从这里开始 - {{ blogBase['title'] }}</title>
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "name": {{ ("从这里开始 - " ~ blogBase.title)|tojson }},
-    "description": "按人生修行、赚钱投资、技术辅助三条原创主线进入人到中年。",
+    "description": "按内心秩序、资产护航、数字能力三条原创主线进入人到中年。",
     "url": {{ (blogBase.homeUrl ~ "/start.html")|tojson }},
     "inLanguage": "zh-CN",
     "isPartOf": {
@@ -61,18 +59,18 @@
 
 {% block content %}
 <main class="start-page">
-    <p class="start-lead">如果你第一次来到这里，可以先按三条主线阅读：想重新理解自己，读人生修行；想管好钱，读赚钱投资；想让工具真正改善生活，读技术辅助。这里优先保留个人实践、长期观察和可复盘的判断，不做资源搬运和新闻聚合。</p>
+    <p class="start-lead">如果你第一次来到这里，可以先按三条主线阅读：想重新理解自己，读内心秩序；想守护家庭资产，读资产护航；想让工具真正改善生活，读数字能力。这里优先保留个人实践、长期观察和可复盘的方法。</p>
     <section class="start-grid" aria-label="内容主线">
-        <a class="start-card" href="{{ blogBase['homeUrl'] }}/xiu-xing.html">
-            <strong>人生修行</strong>
+        <a class="start-card" href="{{ blogBase['homeUrl'] }}/nei-xin-zhi-xu.html">
+            <strong>内心秩序</strong>
             <span>给人生下半场留一点安静的判断力，记录读过的书、想通的事和还没想通的地方。</span>
         </a>
-        <a class="start-card" href="{{ blogBase['homeUrl'] }}/tou-zi.html">
-            <strong>赚钱投资</strong>
+        <a class="start-card" href="{{ blogBase['homeUrl'] }}/zi-chan-hu-hang.html">
+            <strong>资产护航</strong>
             <span>记录大类资产趋势、ETF 配置、实际操作和复盘。重视风险，少一点口号，多一点过程。</span>
         </a>
-        <a class="start-card" href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">
-            <strong>技术辅助</strong>
+        <a class="start-card" href="{{ blogBase['homeUrl'] }}/shu-zi-neng-li.html">
+            <strong>数字能力</strong>
             <span>写给中老年人，也写给需要把技术真正用进生活的人。每篇尽量给出真实场景、操作步骤、风险提醒和亲自验证后的取舍。</span>
         </a>
     </section>
@@ -86,7 +84,7 @@
         <div class="start-actions">
             <a href="{{ blogBase['homeUrl'] }}/subscribe.html">订阅新文章</a>
             <a href="{{ blogBase['homeUrl'] }}/tag.html">查看全部标签</a>
-            <a href="{{ blogBase['xUrl'] }}" target="_blank" rel="noopener">关注 {{ blogBase['xName'] }}</a>
+            {% if blogBase['linkedinUrl'] %}<a href="{{ blogBase['linkedinUrl'] }}" target="_blank" rel="noopener">关注 LinkedIn</a>{% endif %}
         </div>
     </section>
 </main>

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -1,14 +1,12 @@
 {% extends 'base.html' %}
 
 {% block head %}
-<meta name="description" content="订阅人到中年，收到莫白来关于人生修行、赚钱投资与技术辅助的新文章。">
+<meta name="description" content="订阅人到中年，收到莫白来关于内心秩序、资产护航与数字能力的新文章。">
 <meta property="og:title" content="邮件订阅 - {{ blogBase['title'] }}">
 <meta property="og:description" content="少一点噪音，多一点能留下来的判断。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ blogBase['homeUrl'] }}/subscribe.html">
 <meta property="og:image" content="{{ blogBase['ogImage'] }}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:creator" content="@{{ blogBase['xHandle'] }}">
 <title>邮件订阅 - {{ blogBase['title'] }}</title>
 {% if blogBase['turnstileSiteKey'] %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 <script type="application/ld+json">
@@ -16,7 +14,7 @@
     "@context": "https://schema.org",
     "@type": "WebPage",
     "name": {{ ("邮件订阅 - " ~ blogBase.title)|tojson }},
-    "description": "订阅莫白来关于人生修行、赚钱投资与技术辅助的新文章。",
+    "description": "订阅莫白来关于内心秩序、资产护航与数字能力的新文章。",
     "url": {{ (blogBase.homeUrl ~ "/subscribe.html")|tojson }},
     "inLanguage": "zh-CN",
     "isPartOf": {
@@ -71,7 +69,7 @@
 
 {% block content %}
 <main class="subscribe-wrap">
-    <p class="subscribe-lead">少一点噪音，多一点能留下来的判断。这里会更新莫白来关于人生修行、赚钱投资与技术辅助的长文与阶段性札记。</p>
+    <p class="subscribe-lead">少一点噪音，多一点能留下来的判断。这里会更新莫白来关于内心秩序、资产护航与数字能力的长文与阶段性札记。</p>
     <section class="subscribe-panel">
         <h2>收到新文章提醒</h2>
         <p>留下邮箱后会收到一封确认邮件。确认后，只发送新文章和阶段性札记，每封邮件都会带退订入口。</p>
@@ -88,9 +86,9 @@
         <p class="subscribe-note">如果表单暂时不可用，也可以直接写信到 <a href="mailto:{{ blogBase['email'] }}">{{ blogBase['email'] }}</a>，标题写“订阅人到中年”。</p>
     </section>
     <nav class="subscribe-columns" aria-label="栏目">
-        <a href="{{ blogBase['homeUrl'] }}/xiu-xing.html">人生修行</a>
-        <a href="{{ blogBase['homeUrl'] }}/tou-zi.html">赚钱投资</a>
-        <a href="{{ blogBase['homeUrl'] }}/ai-jiao-xue.html">技术辅助</a>
+        <a href="{{ blogBase['homeUrl'] }}/nei-xin-zhi-xu.html">内心秩序</a>
+        <a href="{{ blogBase['homeUrl'] }}/zi-chan-hu-hang.html">资产护航</a>
+        <a href="{{ blogBase['homeUrl'] }}/shu-zi-neng-li.html">数字能力</a>
     </nav>
 </main>
 {% endblock %}

--- a/templates/tag_single.html
+++ b/templates/tag_single.html
@@ -49,7 +49,7 @@
 {% endblock %}
 
 {% block content %}
-{% if current_tag_name == '技术辅助' %}
+{% if current_tag_name == '数字能力' %}
 <section class="tag-intro">
     这个栏目只保留经过实际使用、能解决具体生活问题的教程。本站不把技术写成新闻搬运、工具排行榜或资源下载清单，而是记录真实场景、操作步骤、风险提醒和亲自验证后的取舍。
 </section>


### PR DESCRIPTION
## What changed

- Renames the public pillars to 内心秩序, 资产护航, and 数字能力.
- Adds legacy-label normalization and old category-page redirects without changing article URLs.
- Removes public X, Facebook, and domestic sharing entry points; keeps LinkedIn and email sharing.
- Makes unlabeled, closed, deleted, and Draft issue events run cleanup builds while normal edits remain incremental.
- Prevents ordinary operations files from redeploying the newsletter Worker.

## Why

The site is moving to the Midlife Order positioning and needs a predictable publishing boundary: images alone do not trigger full builds, label changes publish correctly, and withdrawn drafts do not leave stale pages online.

## Checks

- config.json parsed successfully.
- Gmeek.py passed Python AST syntax validation.
- Relevant workflow YAML files parsed successfully.
- git diff --check passed.
- Changes were replayed on the latest main in a clean temporary worktree.

Full rendering and live smoke tests will run after merge through the repository workflow.
